### PR TITLE
Add transition between menu and loading screen

### DIFF
--- a/components/controller/menu_controller.gd
+++ b/components/controller/menu_controller.gd
@@ -1,6 +1,9 @@
 
 extends "res://components/controller/default_controller.gd"
 
+const COLOR_SELECTED = Color(234.0/255,166.0/255,81.0/255)
+const COLOR_UNSELECTED = Color(1,1,1)
+
 var choice
 var choice_list_size
 var cursor
@@ -24,9 +27,9 @@ func update_choice():
   for btn in saves_node.get_children():
     if btn != cursor:
       if btn == saves_node.get_child(choice):
-        btn.add_color_override("font_color", Color(234.0/255,166.0/255,81.0/255))
+        btn.add_color_override("font_color", COLOR_SELECTED)
       else:
-        btn.add_color_override("font_color", Color(1,1,1))
+        btn.add_color_override("font_color", COLOR_UNSELECTED)
 
 func event_up():
   choice = ((choice + choice_list_size - 2) % choice_list_size) + 1

--- a/components/util/transition.gd
+++ b/components/util/transition.gd
@@ -7,23 +7,42 @@ const INVISIBLE_BLACK = Color(42.0/255, 26.0/255, 31.0/255, 0)
 onready var tween = get_node("tween")
 onready var overlay = get_node("overlay")
 
-signal start_transition()
-signal end_transition()
+signal begin_fadeout()
+signal end_fadeout()
+signal begin_fadein()
+signal end_fadein()
+
+func reset_connection(signal_, node_, callback_):
+  disconnect(signal_, node_, callback_)
+
+func configure_fadeout(begin_node, begin_callback, end_node, end_callback):
+  connect("begin_fadeout", begin_node, begin_callback)
+  connect("begin_fadeout", self, "reset_connection", ["begin_fadeout", begin_node, begin_callback])
+  connect("end_fadeout", end_node, end_callback)
+  connect("end_fadeout", self, "reset_connection", ["end_fadeout", end_node, end_callback])
+
+func configure_fadein(begin_node, begin_callback, end_node, end_callback):
+  connect("begin_fadein", begin_node, begin_callback)
+  connect("begin_fadein", self, "reset_connection", ["begin_fadein", begin_node, begin_callback])
+  connect("end_fadein", end_node, end_callback)
+  connect("end_fadein", self, "reset_connection", ["end_fadein", end_node, end_callback])
 
 func fade_to_black(seconds):
-  emit_signal("start_transition")
-  tween.interpolate_method( overlay, "set_color", INVISIBLE_BLACK, BLACK, seconds, Tween.TRANS_QUAD, Tween.EASE_OUT, 0)
+  emit_signal("begin_fadeout")
+  print("fading start!")
+  tween.interpolate_method(overlay, "set_color", INVISIBLE_BLACK, BLACK, seconds, Tween.TRANS_QUAD, Tween.EASE_OUT, 0)
   tween.start()
   yield(tween, "tween_complete")
-  emit_signal("end_transition")
+  emit_signal("end_fadeout")
+  print("fading end!")
 
 func unfade_from_black(seconds):
-  emit_signal("start_transition")
+  emit_signal("begin_fadein")
   print("unfading start!")
-  tween.interpolate_method( overlay, "set_color", BLACK, INVISIBLE_BLACK, seconds, Tween.TRANS_QUAD, Tween.EASE_IN, 0)
+  tween.interpolate_method(overlay, "set_color", BLACK, INVISIBLE_BLACK, seconds, Tween.TRANS_QUAD, Tween.EASE_IN, 0)
   tween.start()
   yield(tween, "tween_complete")
-  emit_signal("end_transition")
+  emit_signal("end_fadein")
   print("unfading end!")
 
 func create_viewport_sized_polygon():

--- a/scenes/menu.gd
+++ b/scenes/menu.gd
@@ -6,7 +6,9 @@ const MenuButton = preload("res://components/ui/save-button.tscn")
 const Route = preload("res://model/route.gd")
 
 onready var loading = get_node("/root/loading")
+onready var transition = get_node("/root/transition")
 onready var saves_node = get_node("saves")
+onready var controller = get_node("controller")
 onready var database = get_node("/root/database")
 onready var profile = database.get_profile()
 
@@ -21,7 +23,7 @@ func start():
     button.set_text(char_name)
     button.connect("selected", self, "_on_load_game_selected", [route_id])
     saves_node.add_child(button)
-  get_node("Controller").setup()
+  controller.setup()
   set_process_input(true)
   show()
 
@@ -33,17 +35,28 @@ func stop():
       button.queue_free()
   set_process_input(false)
 
+func stop_controller():
+  controller.disable()
+
+func transition_out():
+  transition.configure_fadeout(self, "stop_controller", self, "stop")
+
 func _on_new_game_selected():
   print("new game selected!")
-  stop()
-  yield(get_tree(), "idle_frame")
-  yield(get_tree(), "idle_frame")
+  transition_out()
+  transition.fade_to_black(.5)
+  yield(transition, "end_fadeout")
+  transition.unfade_from_black(.5)
+  yield(transition, "end_fadein")
   database.create_route()
+
 
 func _on_load_game_selected(save_id):
   print("load game selected!")
-  stop()
-  yield(get_tree(), "idle_frame")
-  yield(get_tree(), "idle_frame")
+  transition_out()
+  transition.fade_to_black(.5)
+  yield(transition, "end_fadeout")
+  transition.unfade_from_black(.5)
+  yield(transition, "end_fadein")
   database.load_route(save_id)
   get_tree().set_current_scene(get_node("/root/sector"))

--- a/scenes/menu.tscn
+++ b/scenes/menu.tscn
@@ -94,7 +94,7 @@ margin/right = 384.0
 margin/bottom = 28.0
 text = "new route"
 
-[node name="Controller" type="Node" parent="."]
+[node name="controller" type="Node" parent="."]
 
 script/script = ExtResource( 6 )
 

--- a/scenes/menu.tscn
+++ b/scenes/menu.tscn
@@ -75,6 +75,7 @@ alignment = 0
 transform/pos = Vector2( -32, -4 )
 texture = ExtResource( 4 )
 offset = Vector2( 0, 14 )
+modulate = Color( 0.917647, 0.65098, 0.317647, 1 )
 
 [node name="animation" type="AnimationPlayer" parent="saves/cursor"]
 


### PR DESCRIPTION
Also enhanced transition node.
Using the method `configure_fadeout` or `configure_fadein` you can make setup functions to happen at certain points of the transition.

It is also advised to use yield for the signals that the transition node uses, like `begin_fadeout` or `end_fadein`. Check the `transition.gd` for more info.