### PR TITLE
Prettify and enhance menu fade in

### DIFF
--- a/components/controller/menu_controller.gd
+++ b/components/controller/menu_controller.gd
@@ -46,6 +46,6 @@ func event_down():
 func event_select():
   var selection = saves_node.get_child(choice)
   assert(selection != cursor) # redundant check yay
-  selection.emit_signal("selected")
   self.disable()
   cursor.hide()
+  selection.emit_signal("selected")

--- a/components/controller/menu_controller.gd
+++ b/components/controller/menu_controller.gd
@@ -11,10 +11,14 @@ var saves_node
 
 onready var menu = get_parent()
 
-func setup():
+func _ready():
   choice = 1 # default to new route choice
+  self.disable()
+
+func setup():
   saves_node = menu.saves_node
   cursor = saves_node.get_node("cursor")
+  cursor.show()
   choice_list_size = saves_node.get_child_count() - 1
   self.enable()
   self.update_choice()
@@ -44,3 +48,4 @@ func event_select():
   assert(selection != cursor) # redundant check yay
   selection.emit_signal("selected")
   self.disable()
+  cursor.hide()

--- a/components/util/transition.gd
+++ b/components/util/transition.gd
@@ -29,20 +29,28 @@ func configure_fadein(begin_node, begin_callback, end_node, end_callback):
 
 func fade_to_black(seconds):
   emit_signal("begin_fadeout")
+  if is_connected("begin_fadeout", self, "reset_connection"):
+    disconnect("begin_fadeout", self, "reset_connection")
   print("fading start!")
   tween.interpolate_method(overlay, "set_color", INVISIBLE_BLACK, BLACK, seconds, Tween.TRANS_QUAD, Tween.EASE_OUT, 0)
   tween.start()
   yield(tween, "tween_complete")
   emit_signal("end_fadeout")
+  if is_connected("end_fadeout", self, "reset_connection"):
+    disconnect("end_fadeout", self, "reset_connection")
   print("fading end!")
 
 func unfade_from_black(seconds):
   emit_signal("begin_fadein")
+  if is_connected("begin_fadein", self, "reset_connection"):
+    disconnect("begin_fadein", self, "reset_connection")
   print("unfading start!")
   tween.interpolate_method(overlay, "set_color", BLACK, INVISIBLE_BLACK, seconds, Tween.TRANS_QUAD, Tween.EASE_IN, 0)
   tween.start()
   yield(tween, "tween_complete")
   emit_signal("end_fadein")
+  if is_connected("end_fadein", self, "reset_connection"):
+    disconnect("end_fadein", self, "reset_connection")
   print("unfading end!")
 
 func create_viewport_sized_polygon():
@@ -57,4 +65,3 @@ func create_viewport_sized_polygon():
 func _ready():
   overlay.set_polygon(create_viewport_sized_polygon())
   overlay.set_color(BLACK)
-  unfade_from_black(1.0)

--- a/components/util/transition.gd
+++ b/components/util/transition.gd
@@ -12,45 +12,30 @@ signal end_fadeout()
 signal begin_fadein()
 signal end_fadein()
 
-func reset_connection(signal_, node_, callback_):
-  disconnect(signal_, node_, callback_)
-
 func configure_fadeout(begin_node, begin_callback, end_node, end_callback):
-  connect("begin_fadeout", begin_node, begin_callback)
-  connect("begin_fadeout", self, "reset_connection", ["begin_fadeout", begin_node, begin_callback])
-  connect("end_fadeout", end_node, end_callback)
-  connect("end_fadeout", self, "reset_connection", ["end_fadeout", end_node, end_callback])
+  connect("begin_fadeout", begin_node, begin_callback, [], CONNECT_ONESHOT)
+  connect("end_fadeout", end_node, end_callback, [], CONNECT_ONESHOT)
 
 func configure_fadein(begin_node, begin_callback, end_node, end_callback):
-  connect("begin_fadein", begin_node, begin_callback)
-  connect("begin_fadein", self, "reset_connection", ["begin_fadein", begin_node, begin_callback])
-  connect("end_fadein", end_node, end_callback)
-  connect("end_fadein", self, "reset_connection", ["end_fadein", end_node, end_callback])
+  connect("begin_fadein", begin_node, begin_callback, [], CONNECT_ONESHOT)
+  connect("end_fadein", end_node, end_callback, [], CONNECT_ONESHOT)
 
 func fade_to_black(seconds):
   emit_signal("begin_fadeout")
-  if is_connected("begin_fadeout", self, "reset_connection"):
-    disconnect("begin_fadeout", self, "reset_connection")
   print("fading start!")
   tween.interpolate_method(overlay, "set_color", INVISIBLE_BLACK, BLACK, seconds, Tween.TRANS_QUAD, Tween.EASE_OUT, 0)
   tween.start()
   yield(tween, "tween_complete")
   emit_signal("end_fadeout")
-  if is_connected("end_fadeout", self, "reset_connection"):
-    disconnect("end_fadeout", self, "reset_connection")
   print("fading end!")
 
 func unfade_from_black(seconds):
   emit_signal("begin_fadein")
-  if is_connected("begin_fadein", self, "reset_connection"):
-    disconnect("begin_fadein", self, "reset_connection")
   print("unfading start!")
   tween.interpolate_method(overlay, "set_color", BLACK, INVISIBLE_BLACK, seconds, Tween.TRANS_QUAD, Tween.EASE_IN, 0)
   tween.start()
   yield(tween, "tween_complete")
   emit_signal("end_fadein")
-  if is_connected("end_fadein", self, "reset_connection"):
-    disconnect("end_fadein", self, "reset_connection")
   print("unfading end!")
 
 func create_viewport_sized_polygon():

--- a/scenes/menu.gd
+++ b/scenes/menu.gd
@@ -24,7 +24,7 @@ func start():
     button.connect("selected", self, "_on_load_game_selected", [route_id])
     saves_node.add_child(button)
   show()
-  transition.unfade_from_black(1.5)
+  transition.unfade_from_black(.5)
   yield(transition, "end_fadein")
   controller.setup()
 

--- a/scenes/menu.gd
+++ b/scenes/menu.gd
@@ -24,9 +24,8 @@ func start():
     button.connect("selected", self, "_on_load_game_selected", [route_id])
     saves_node.add_child(button)
   show()
+  transition.connect("end_fadein", controller, "setup", [], CONNECT_ONESHOT)
   transition.unfade_from_black(.5)
-  yield(transition, "end_fadein")
-  controller.setup()
 
 func stop():
   hide()
@@ -35,28 +34,22 @@ func stop():
     if button.get_name() != "new_game" and button.get_name() != "cursor":
       button.queue_free()
 
-func stop_controller():
-  controller.disable()
-
-func transition_out():
-  transition.configure_fadeout(self, "stop_controller", self, "stop")
+func transition_out(database_action, file):
+  #transition.configure_fadeout(controller, "disable", self, "stop")
+  #transition.connect("begin_fadeout", controller, "disable", [], CONNECT_ONESHOT)
+  transition.connect("end_fadeout", self, "stop", [], CONNECT_ONESHOT)
+  transition.connect("end_fadeout", transition, "unfade_from_black", [.5], CONNECT_ONESHOT)
+  if not file:
+    transition.connect("end_fadein", database, database_action, [], CONNECT_ONESHOT)
+  else:
+    transition.connect("end_fadein", database, database_action, [file], CONNECT_ONESHOT)
+  transition.fade_to_black(.5)
 
 func _on_new_game_selected():
   print("new game selected!")
-  transition_out()
-  transition.fade_to_black(.5)
-  yield(transition, "end_fadeout")
-  transition.unfade_from_black(.5)
-  yield(transition, "end_fadein")
-  database.create_route()
-
+  transition_out("create_route", false)
 
 func _on_load_game_selected(save_id):
   print("load game selected!")
-  transition_out()
-  transition.fade_to_black(.5)
-  yield(transition, "end_fadeout")
-  transition.unfade_from_black(.5)
-  yield(transition, "end_fadein")
-  database.load_route(save_id)
+  transition_out("load_route", save_id)
   get_tree().set_current_scene(get_node("/root/sector"))

--- a/scenes/menu.gd
+++ b/scenes/menu.gd
@@ -23,9 +23,10 @@ func start():
     button.set_text(char_name)
     button.connect("selected", self, "_on_load_game_selected", [route_id])
     saves_node.add_child(button)
-  controller.setup()
-  set_process_input(true)
   show()
+  transition.unfade_from_black(1.5)
+  yield(transition, "end_fadein")
+  controller.setup()
 
 func stop():
   hide()
@@ -33,7 +34,6 @@ func stop():
   for button in saves_node.get_children():
     if button.get_name() != "new_game" and button.get_name() != "cursor":
       button.queue_free()
-  set_process_input(false)
 
 func stop_controller():
   controller.disable()

--- a/scenes/menu.gd
+++ b/scenes/menu.gd
@@ -35,8 +35,6 @@ func stop():
       button.queue_free()
 
 func transition_out(database_action, file):
-  #transition.configure_fadeout(controller, "disable", self, "stop")
-  #transition.connect("begin_fadeout", controller, "disable", [], CONNECT_ONESHOT)
   transition.connect("end_fadeout", self, "stop", [], CONNECT_ONESHOT)
   transition.connect("end_fadeout", transition, "unfade_from_black", [.5], CONNECT_ONESHOT)
   if not file:

--- a/scenes/menu.tscn
+++ b/scenes/menu.tscn
@@ -72,6 +72,7 @@ alignment = 0
 
 [node name="cursor" type="Sprite" parent="saves"]
 
+visibility/visible = false
 transform/pos = Vector2( -32, -4 )
 texture = ExtResource( 4 )
 offset = Vector2( 0, 14 )


### PR DESCRIPTION
Everytime menu loads, there is a fade in transition. At its end the menu controller is loaded and enabled.
Also transition now uses connects in a simpler way, but you can still use yields if you prefer.