### PR TITLE
Map/Sector construction now uses previously implemented generation algorythms

### DIFF
--- a/game/database/sector1.json
+++ b/game/database/sector1.json
@@ -1,0 +1,40 @@
+{
+  "general": {
+    "width": 32,
+    "height": 32,
+    "mw": 3,
+    "mh": 3,
+  },
+  "transformers": [
+    {
+      "name": "rooms",
+      "params": {
+        "minw": 3,
+        "minh": 3,
+        "maxw": 7,
+        "maxh": 7,
+        "count": 12,
+        "tries": 256,
+      }
+    },
+    {
+      "name": "maze",
+      "params": {
+        "double": false
+      }
+    },
+    {
+      "name": "connections",
+      "params": {
+        "n": 128
+      }
+    },
+    {
+      "name": "deadends",
+      "params": {
+        "n": 128,
+      }
+    }
+
+  ]
+}

--- a/game/gamestates/play.lua
+++ b/game/gamestates/play.lua
@@ -61,7 +61,7 @@ function state:enter()
 
   _route = Route()
 
-  _current_map = Map(20,20)
+  _current_map = Map("sector1")
   _route.register(_current_map)
   _map_view = MapView(_current_map)
   _map_view:addElement("L1", nil, "map_view")
@@ -208,4 +208,3 @@ end
 
 --Return state functions
 return state
-


### PR DESCRIPTION
Related to: #161 

All I did was:

1. Add a new `json` file to the `database` directory. It contains the parametres for constructing a sector.
2. Change `Map:init()` to receive the database entry name instead of width and height. It now runs the generation and transformer modules in `domain/transformers/`, and creates the sector based on the generated `MapGrid` object.