### PR TITLE
Screenflick Fix

### DIFF
--- a/game/gamestates/pick_target.lua
+++ b/game/gamestates/pick_target.lua
@@ -50,7 +50,7 @@ function state:enter(_, actor, sector, sector_view, target_opt)
           target_is_valid = true,
           pos = {_sector_view:getCursorPos()}
         }
-        Gamestate.pop(args)
+        SWITCHER.pop(args)
     end
   end
 
@@ -58,7 +58,7 @@ function state:enter(_, actor, sector, sector_view, target_opt)
       local args = {
         target_is_valid = false,
       }
-      Gamestate.pop(args)
+      SWITCHER.pop(args)
   end
 
   Signal.register("move_cursor", move_cursor)

--- a/game/gamestates/play.lua
+++ b/game/gamestates/play.lua
@@ -69,7 +69,7 @@ local function _usePrimaryAction()
   local params = {}
   for _,param in ACTION.paramsOf(action_name) do
     if param[1] == 'choose_target' then
-      Gamestate.push(
+      SWITCHER.push(
         GS.PICK_TARGET, _controlled_actor, _current_sector, _sector_view,
         {
           pos = {_controlled_actor:getPos()},

--- a/game/infra/switcher.lua
+++ b/game/infra/switcher.lua
@@ -1,0 +1,37 @@
+
+local Gamestate = require "steaming.extra_libs.hump.gamestate"
+
+local SWITCHER = {}
+
+local _pushed = false
+local _popped = false
+
+function SWITCHER.push (to, ...)
+  _pushed = { to, ... }
+end
+
+function SWITCHER.pop (...)
+  _popped = { ... }
+end
+
+function SWITCHER.override ()
+  Gamestate.registerEvents()
+  local draw = love.draw
+  love.draw = function (...)
+    draw(...)
+    if _popped then
+      Gamestate.pop(unpack(_popped))
+      _popped = false
+    end
+    if _pushed then
+      Gamestate.push(unpack(_pushed))
+      _pushed = false
+    end
+  end
+end
+
+setmetatable(SWITCHER, {
+  __index = Gamestate
+})
+
+return SWITCHER

--- a/game/main.lua
+++ b/game/main.lua
@@ -6,7 +6,6 @@ imgui     = require 'imgui'
 cpml      = require 'cpml'
 
 -- HUMP
-Gamestate = require "steaming.extra_libs.hump.gamestate"
 Timer     = require "steaming.extra_libs.hump.timer"
 Class     = require "steaming.extra_libs.hump.class"
 Camera    = require "steaming.extra_libs.hump.camera"
@@ -31,6 +30,9 @@ GS = {
     PICK_TARGET = require "gamestates.pick_target", --Player is choosing targets
 }
 
+-- GAMESTATE SWITCHER
+SWITCHER = require 'infra.switcher'
+
 ------------------
 --LÖVE FUNCTIONS--
 ------------------
@@ -39,7 +41,9 @@ function love.load(arg)
 
     Setup.config() --Configure your game
 
-    Gamestate.registerEvents() --Overwrites love callbacks to call Gamestate as well
+
+    SWITCHER.override() --Overwrites love callbacks to call Gamestate as well
+
 
     --[[
         Setup support for multiple resolutions. Res.init() Must be called after Gamestate.registerEvents()
@@ -47,8 +51,9 @@ function love.load(arg)
     ]]
     Res.init()
 
-    Gamestate.switch(GS.PLAY) --Jump to the inicial state
 
+    SWITCHER.switch(GS.PLAY) --Jump to the inicial state
+    
 end
 
 function love.quit()


### PR DESCRIPTION
To fix the screenflick issue (#156), I have written a overrider for hump's overrider.

This is simply a wrapper called `SWITCHER`, located in `game/infra/switcher.lua`. It includes a function called `override`, that calls hump's `Gamestate.registerEvents`, and wraps the `love.draw` function to handle switching states.

I have thus removed the global `Gamestate` and switched it to another, called `SWITCHER`. We now must use that instead of `Gamestate` to change between states.