### PR TITLE
Add a start menu

### DIFF
--- a/game/domain/view/hudview.lua
+++ b/game/domain/view/hudview.lua
@@ -32,7 +32,6 @@ function HudView:draw()
   local g = love.graphics
   g.push()
   for i = 1, self.size do
-    print(unpack(self.queue[i]))
     g[self.queue[i][1]](unpack(self.queue[i], 2))
   end
   g.pop()

--- a/game/domain/view/hudview.lua
+++ b/game/domain/view/hudview.lua
@@ -1,0 +1,42 @@
+
+local HudView = Class{
+  __includes = { ELEMENT }
+}
+
+function HudView:init()
+  ELEMENT.init(self)
+
+  self.queue = {}
+  self.size = 0
+  self.x, self.y = 0, 0
+
+end
+
+function HudView:setPos (x, y)
+  self.x, self.y = x, y
+end
+
+function HudView:push(draw_instruction)
+  self.size = self.size + 1
+  self.queue[self.size] = draw_instruction
+end
+
+function HudView:clear()
+  for i = 1, self.size do
+    self.queue[i] = nil
+  end
+  self.size = 0
+end
+
+function HudView:draw()
+  local g = love.graphics
+  g.push()
+  for i = 1, self.size do
+    print(unpack(self.queue[i]))
+    g[self.queue[i][1]](unpack(self.queue[i], 2))
+  end
+  g.pop()
+  self:clear()
+end
+
+return HudView

--- a/game/draw.lua
+++ b/game/draw.lua
@@ -24,6 +24,8 @@ function draw.allTables()
 
     CAM:detach() --Stop tracking camera
 
+    DrawTable(DRAW_TABLE.HUD)
+
     if DEBUG and first_time then
       fade = tween.start(0, 50, 5)
       first_time = false
@@ -35,8 +37,6 @@ function draw.allTables()
     g.setColor(255, 255, 255, fade())
     g.rectangle('fill', 0, 0, 1280, 720)
 
-    DrawTable(DRAW_TABLE.HUD)
-    
     DrawTable(DRAW_TABLE.GUI)
 
     SWITCHER.handleChangedState()

--- a/game/draw.lua
+++ b/game/draw.lua
@@ -35,6 +35,8 @@ function draw.allTables()
     g.setColor(255, 255, 255, fade())
     g.rectangle('fill', 0, 0, 1280, 720)
 
+    DrawTable(DRAW_TABLE.HUD)
+    
     DrawTable(DRAW_TABLE.GUI)
 
     SWITCHER.handleChangedState()

--- a/game/gamestates/pick_target.lua
+++ b/game/gamestates/pick_target.lua
@@ -72,7 +72,7 @@ function state:enter(_, sector_view, target_opt)
       end
   end
   _previous_control_map = CONTROL.getMap()
-  CONTROL.set_map(signals)
+  CONTROL.setMap(signals)
 
 end
 
@@ -82,7 +82,7 @@ function state:leave()
     Signal.clear("cancel")
 
     _sector_view:removeCursor()
-    CONTROL.set_map(_previous_control_map)
+    CONTROL.setMap(_previous_control_map)
 end
 
 function state:update(dt)

--- a/game/gamestates/play.lua
+++ b/game/gamestates/play.lua
@@ -132,7 +132,7 @@ function state:enter()
 
   Signal.register("move", _makeSignalHandler(_moveActor))
   Signal.register("widget_1", _makeSignalHandler(_usePrimaryAction))
-  CONTROL.set_map(SIGNALS)
+  CONTROL.setMap(SIGNALS)
 
   _gui = GUI(_sector_view)
   _gui:addElement("GUI")
@@ -225,4 +225,3 @@ end
 
 --Return state functions
 return state
-

--- a/game/gamestates/start_menu.lua
+++ b/game/gamestates/start_menu.lua
@@ -14,14 +14,6 @@ local _font
 
 --LOCAL FUNCTIONS--
 
-local function _sendToLayer ()
-  local render_queue = MENU.getRenderQueue()
-  while not render_queue.isEmpty() do
-    local printing = render_queue.pop()
-    _menu_view:push(printing)
-  end
-end
-
 local function _title ()
   _menu_view:push { "setFont", _font }
   _menu_view:push { "setColor", 0xff, 0xff, 0xff, 0xff }
@@ -69,7 +61,7 @@ function state:update (dt)
   end
   MENU.finish()
   _title()
-  _sendToLayer()
+  MENU.flush(_menu_view)
 end
 
 function state:draw ()

--- a/game/gamestates/start_menu.lua
+++ b/game/gamestates/start_menu.lua
@@ -1,0 +1,84 @@
+--MODULE FOR THE GAMESTATE: GAME--
+local MENU = require 'infra.menu'
+local INPUT = require 'infra.input'
+local CONTROLS = require 'infra.control'
+local HudView = require 'domain.view.hudview'
+
+local state = {}
+
+--LOCAL VARIABLES--
+
+local _width, _height
+local _menu_view
+
+--LOCAL FUNCTIONS--
+
+local function _sendToLayer ()
+  local render_queue = MENU.getRenderQueue()
+  while not render_queue.isEmpty() do
+    local printing = render_queue.pop()
+    _menu_view:push(printing)
+  end
+end
+
+--STATE FUNCTIONS--
+
+function state:init ()
+  _menu_view = HudView()
+  _width, _height = love.window.getMode()
+end
+
+function state:enter ()
+  _menu_view:addElement("HUD", nil, "menu_view")
+  print(Util.findId("menu_view"))
+  CONTROLS.setMap {
+    PRESS_ACTION_1 = MENU.confirm,
+    PRESS_SPECIAL  = MENU.cancel,
+    PRESS_CANCEL   = MENU.cancel,
+    PRESS_QUIT     = MENU.cancel,
+    PRESS_UP       = MENU.prev,
+    PRESS_DOWN     = MENU.next,
+  }
+end
+
+function state:leave ()
+  _menu_view:destroy()
+end
+
+function state:update (dt)
+  INPUT.update()
+  if MENU.begin("START_MENU", _width / 2 - 160, _height / 2, false, 320) then
+    if MENU.item("NEW ROUTE") then
+      SWITCHER.switch(GS.PLAY)
+    end
+    if MENU.item("LOAD ROUTE") then
+      print("Not implemented yet")
+    end
+    if MENU.item("QUIT") then
+      love.event.quit()
+    end
+  else
+    love.event.quit()
+  end
+  MENU.finish()
+  _sendToLayer()
+end
+
+function state:draw ()
+  Draw.allTables()
+end
+
+function state:keypressed(key)
+  INPUT.key_pressed(key)
+end
+
+function state:keyreleased(key)
+  INPUT.key_released(key)
+end
+
+function state:getView ()
+  return _menu_view
+end
+
+--Return state functions
+return state

--- a/game/gamestates/start_menu.lua
+++ b/game/gamestates/start_menu.lua
@@ -10,6 +10,7 @@ local state = {}
 
 local _width, _height
 local _menu_view
+local _font
 
 --LOCAL FUNCTIONS--
 
@@ -21,16 +22,22 @@ local function _sendToLayer ()
   end
 end
 
+local function _title ()
+  _menu_view:push { "setFont", _font }
+  _menu_view:push { "setColor", 0xff, 0xff, 0xff, 0xff }
+  _menu_view:push { "print", "backdoor", 80*4, _height/4 }
+end
+
 --STATE FUNCTIONS--
 
 function state:init ()
   _menu_view = HudView()
+  _font = love.graphics.newFont(48)
   _width, _height = love.window.getMode()
 end
 
 function state:enter ()
   _menu_view:addElement("HUD", nil, "menu_view")
-  print(Util.findId("menu_view"))
   CONTROLS.setMap {
     PRESS_ACTION_1 = MENU.confirm,
     PRESS_SPECIAL  = MENU.cancel,
@@ -47,20 +54,21 @@ end
 
 function state:update (dt)
   INPUT.update()
-  if MENU.begin("START_MENU", _width / 2 - 160, _height / 2, false, 320) then
-    if MENU.item("NEW ROUTE") then
+  if MENU.begin("START_MENU", 80*4, _height / 2) then
+    if MENU.item("New route") then
       SWITCHER.switch(GS.PLAY)
     end
-    if MENU.item("LOAD ROUTE") then
+    if MENU.item("Load route") then
       print("Not implemented yet")
     end
-    if MENU.item("QUIT") then
+    if MENU.item("Quit") then
       love.event.quit()
     end
   else
     love.event.quit()
   end
   MENU.finish()
+  _title()
   _sendToLayer()
 end
 

--- a/game/infra/control.lua
+++ b/game/infra/control.lua
@@ -25,7 +25,7 @@ function controls.flush ()
   input_queue.popAll()
 end
 
-function controls.set_map (m)
+function controls.setMap (m)
   setmetatable(m, redirect)
   mapped_controls = m
 end
@@ -43,5 +43,5 @@ function controls.update ()
   input_queue.popAll()
 end
 
-controls.set_map(mapped_controls)
+controls.setMap(mapped_controls)
 return controls

--- a/game/infra/menu.lua
+++ b/game/infra/menu.lua
@@ -36,14 +36,14 @@ end
 
 -- check movement
 local function _checkMovement()
-  if _actions.next then _registered[name] = _registered[name] + 1 end
-  if _actions.prev then _registered[name] = _registered[name] - 1 end
+  if _actions.next then _registered[_current] = _registered[_current] + 1 end
+  if _actions.prev then _registered[_current] = _registered[_current] - 1 end
   return true
 end
 
 -- check height
 local function _checkDimensions ()
-  _width = 2*PD
+  _width = math.max(_width, 2*PD)
   if _scroll_interval then _height = _scroll_interval*LH + 2*PD
   else _height = PD end
   return true
@@ -71,7 +71,7 @@ local function _updateScroll()
 end
 
 -- start menu
-function Menu.begin(name, x, y, scroll)
+function Menu.begin(name, x, y, scroll, static_width)
   -- register new menu
   if _current ~= name then
     _registered[name] = 1
@@ -80,11 +80,11 @@ function Menu.begin(name, x, y, scroll)
     _scroll_top = 1
     _count = 0
     _size = 0
-    _width, _height = 0, 0
+    _width, _height = static_width or 0, 0
   end
 
   -- push menu position
-  _renderqueue.push { "translate", x, y }
+  _renderqueue.push { "translate", x or 0, y or 0 }
 
   -- check menu input and set menu box minimal dimensions
   return _checkCancel() and _checkMovement() and _checkDimensions()
@@ -125,6 +125,7 @@ end
 function Menu.finish()
   -- update menu size
   _size = _count
+  _count = 0
 
   -- reposition selection if out of bounds
   if _selection() > _size then _selection(1)

--- a/game/infra/menu.lua
+++ b/game/infra/menu.lua
@@ -12,7 +12,7 @@ local _size
 local _width, _height
 local _itemqueue = Queue(64)
 local _renderqueue = Queue(64)
-local _font = love.graphics.newFont(16)
+local _font = love.graphics.newFont(20)
 local _actions = {
   confirm = false,
   cancel = false,
@@ -21,7 +21,7 @@ local _actions = {
 }
 
 -- padding, lineheight
-local PD, LH = 16, 24
+local PD, LH = 32, 20
 
 -- get/set selection
 local function _selection(n)
@@ -96,7 +96,8 @@ function Menu.item(item)
   _count = _count + 1
 
   -- update width to match max item width
-  _width = math.max(_width, _font:getWidth(item))
+  local linewidth = _font:getWidth(item)
+  _width = _width < linewidth+2*PD and _width+linewidth or _width
 
   -- scroll item in limitted box
   if not _scroll_interval or _count >= _scroll_top
@@ -139,6 +140,7 @@ function Menu.finish()
   _renderqueue.push { "rectangle", "fill", 0, 0, _width, _height }
 
   -- push items to render queue
+  _renderqueue.push { "setFont", _font }
   while not _itemqueue.isEmpty() do
     _renderqueue.push(_itemqueue.pop())
     _renderqueue.push(_itemqueue.pop())

--- a/game/infra/menu.lua
+++ b/game/infra/menu.lua
@@ -8,6 +8,7 @@ local _scroll_interval
 local _scroll_top
 local _count
 local _current
+local _size
 local _width, _height
 local _itemqueue = Queue(64)
 local _renderqueue = Queue(64)
@@ -78,6 +79,7 @@ function Menu.begin(name, x, y, scroll)
     _scroll_interval = scroll
     _scroll_top = 1
     _count = 0
+    _size = 0
     _width, _height = 0, 0
   end
 
@@ -121,10 +123,18 @@ end
 
 
 function Menu.finish()
+  -- update menu size
+  _size = _count
+
+  -- reposition selection if out of bounds
+  if _selection() > _size then _selection(1)
+  elseif _selection() < 1 then _selection(_size) end
+
   -- update scrolling, if there is any
   _updateScroll()
 
   -- draw menu container
+  _renderqueue.push { "setColor", 0x20, 0x20, 0x20, 0xff }
   _renderqueue.push { "rectangle", "fill", 0, 0, _width, _height }
 
   -- push items to render queue
@@ -143,9 +153,32 @@ function Menu.cancel() _actions.cancel = true end
 function Menu.next() _actions.next = true end
 function Menu.prev() _actions.prev = true end
 
--- getter
+-- getters
 function Menu.getRenderQueue ()
+  -- render queue
   return _renderqueue
+end
+
+function Menu.getSelection ()
+  -- currently selected index
+  return _selection()
+end
+
+function Menu.getSize ()
+  -- total number of items in menu
+  return _size
+end
+
+function Menu.hasItemsAbove ()
+  -- if you can scroll up
+  return _scroll_interval and _scroll_top > 1
+    and _scroll_top - 1
+end
+
+function Menu.hasItemsBelow ()
+  -- if you can scroll down
+  return _scroll_interval and _scroll_top < _size - _scroll_interval
+    and _size - _scroll_top - _scroll_interval
 end
 
 return Menu

--- a/game/infra/menu.lua
+++ b/game/infra/menu.lua
@@ -1,8 +1,13 @@
-
+-- DEPENDENCIES --
 local Queue = require 'lux.common.Queue'
 
-local Menu = {}
 
+-- CONSTANTS --
+local PD, LH = 32, 20 -- padding, lineheight
+
+
+-- PRIVATE VARIABLES --
+local Menu = {}
 local _registered = {}
 local _scroll_interval
 local _scroll_top
@@ -20,9 +25,8 @@ local _actions = {
   prev = false,
 }
 
--- padding, lineheight
-local PD, LH = 32, 20
 
+-- PRIVATE METHODS --
 -- get/set selection
 local function _selection(n)
   _registered[_current] = n or _registered[_current]
@@ -150,18 +154,21 @@ function Menu.finish()
   for k in pairs(_actions) do _actions[k] = false end
 end
 
--- menu actions
+function Menu.flush (menu_view)
+  while not _renderqueue.isEmpty() do
+    menu_view:push(_renderqueue.pop())
+  end
+end
+
+
+-- MENU ACTIONS --
 function Menu.confirm() _actions.confirm = true end
 function Menu.cancel() _actions.cancel = true end
 function Menu.next() _actions.next = true end
 function Menu.prev() _actions.prev = true end
 
--- getters
-function Menu.getRenderQueue ()
-  -- render queue
-  return _renderqueue
-end
 
+-- GETTERS --
 function Menu.getSelection ()
   -- currently selected index
   return _selection()

--- a/game/infra/menu.lua
+++ b/game/infra/menu.lua
@@ -1,0 +1,151 @@
+
+local Queue = require 'lux.common.Queue'
+
+local Menu = {}
+
+local _registered = {}
+local _scroll_interval
+local _scroll_top
+local _count
+local _current
+local _width, _height
+local _itemqueue = Queue(64)
+local _renderqueue = Queue(64)
+local _font = love.graphics.newFont(16)
+local _actions = {
+  confirm = false,
+  cancel = false,
+  next = false,
+  prev = false,
+}
+
+-- padding, lineheight
+local PD, LH = 16, 24
+
+-- get/set selection
+local function _selection(n)
+  _registered[_current] = n or _registered[_current]
+  return _registered[_current]
+end
+
+-- check cancel
+local function _checkCancel()
+  return not _actions.cancel
+end
+
+-- check movement
+local function _checkMovement()
+  if _actions.next then _registered[name] = _registered[name] + 1 end
+  if _actions.prev then _registered[name] = _registered[name] - 1 end
+  return true
+end
+
+-- check height
+local function _checkDimensions ()
+  _width = 2*PD
+  if _scroll_interval then _height = _scroll_interval*LH + 2*PD
+  else _height = PD end
+  return true
+end
+
+-- check if item was selected
+local function _isSelected()
+  return _count == _selection()
+end
+
+-- check if item was confirmed
+local function _isConfirmed()
+  return _isSelected() and _actions.confirm
+end
+
+-- updates scrolling
+local function _updateScroll()
+  if _scroll_interval then
+    if _scroll_top > _selection() then
+      _scroll_top = _selection()
+    elseif _selection - _scroll_top > _scroll_interval then
+      _scroll_top = _selection - _scroll_top
+    end
+  end
+end
+
+-- start menu
+function Menu.begin(name, x, y, scroll)
+  -- register new menu
+  if _current ~= name then
+    _registered[name] = 1
+    _current = name
+    _scroll_interval = scroll
+    _scroll_top = 1
+    _count = 0
+    _width, _height = 0, 0
+  end
+
+  -- push menu position
+  _renderqueue.push { "translate", x, y }
+
+  -- check menu input and set menu box minimal dimensions
+  return _checkCancel() and _checkMovement() and _checkDimensions()
+end
+
+-- check menuitem
+function Menu.item(item)
+  -- increment item count
+  _count = _count + 1
+
+  -- update width to match max item width
+  _width = math.max(_width, _font:getWidth(item))
+
+  -- scroll item in limitted box
+  if not _scroll_interval or _count >= _scroll_top
+    and _count <= _scroll_top + _scroll_interval then
+
+    -- check if selected
+    if _count == _selection() then
+      -- set to look bright if selected
+      _itemqueue.push { "setColor", 0xff, 0xff, 0xff, 0xff }
+    else
+      -- set to look faded if not selected
+      _itemqueue.push { "setColor", 0x80, 0x80, 0x80, 0x80 }
+    end
+
+    -- push item to item queue
+    _itemqueue.push { "print", item, PD, _height }
+
+    -- update height
+    _height = _height + LH + PD
+  end
+
+  return _isConfirmed()
+end
+
+
+function Menu.finish()
+  -- update scrolling, if there is any
+  _updateScroll()
+
+  -- draw menu container
+  _renderqueue.push { "rectangle", "fill", 0, 0, _width, _height }
+
+  -- push items to render queue
+  while not _itemqueue.isEmpty() do
+    _renderqueue.push(_itemqueue.pop())
+    _renderqueue.push(_itemqueue.pop())
+  end
+
+  -- reset actions' states
+  for k in pairs(_actions) do _actions[k] = false end
+end
+
+-- menu actions
+function Menu.confirm() _actions.confirm = true end
+function Menu.cancel() _actions.cancel = true end
+function Menu.next() _actions.next = true end
+function Menu.prev() _actions.prev = true end
+
+-- getter
+function Menu.getRenderQueue ()
+  return _renderqueue
+end
+
+return Menu

--- a/game/main.lua
+++ b/game/main.lua
@@ -28,6 +28,7 @@ Setup     = require "setup"
 GS = {
     PLAY = require "gamestates.play",     --Game Gamestate
     PICK_TARGET = require "gamestates.pick_target", --Player is choosing targets
+    START_MENU = require "gamestates.start_menu", --Player is choosing targets
 }
 
 -- GAMESTATE SWITCHER
@@ -52,7 +53,7 @@ function love.load(arg)
     Res.init()
 
 
-    SWITCHER.switch(GS.PLAY) --Jump to the inicial state
+    SWITCHER.switch(GS.START_MENU) --Jump to the inicial state
 
 end
 

--- a/game/setup.lua
+++ b/game/setup.lua
@@ -28,7 +28,8 @@ function setup.config()
         BG  = {}, --Background (bottom layer, first to draw)
         L1  = {}, --Layer 1
         L2  = {}, --Layer 2
-        GUI = {}  --Graphic User Interface (top layer, last to draw)
+        HUD = {}, --HUD (top layer, second to last to draw)
+        GUI = {}, --Graphic User Interface (top layer, last to draw)
     }
     --Other Tables
     SUBTP_TABLE = {} --Table with tables for each subtype (for fast lookup)


### PR DESCRIPTION
This also adds a imgui-like menu module in `infra.menu`. And a sample start menu state to begin the game.

You can make your own menus with it. Check `game/gamestates/start_menu.lua` to see its usage. It's pretty powerful, at the expense of all menus derived from it looking alike. You can ignore it's drawing queue and make your own as well, if you want a more visually customizeable menu. But the logic usage is pretty easy to use either way.