### PR TITLE
Basic profile module (does not save routes yet)

### DIFF
--- a/game/gamestates/start_menu.lua
+++ b/game/gamestates/start_menu.lua
@@ -52,8 +52,8 @@ function state:update (dt)
   if MENU.begin(_menu_context, 80*4, _height / 2, 3, 160) then
     if _menu_context == "START_MENU" then
       if MENU.item("New route") then
-        local route_id = PROFILE.newRoute()
-        SWITCHER.switch(GS.PLAY, route_id)
+        local route_data = PROFILE.newRoute()
+        SWITCHER.switch(GS.PLAY, route_data)
       end
       if MENU.item("Load route") then
         _menu_context = "LOAD_LIST"
@@ -64,8 +64,8 @@ function state:update (dt)
     elseif _menu_context == "LOAD_LIST" then
       local savelist = PROFILE.getSaveList()
       if #savelist > 0 then
-        for _,route_id in ipairs(savelist) do
-          if MENU.item(route_id) then
+        for route_id, route_header in pairs(savelist) do
+          if MENU.item(route_header.charname) then
             SWITCHER.switch(GS.PLAY, PROFILE.loadRoute(route_id))
           end
         end

--- a/game/gamestates/start_menu.lua
+++ b/game/gamestates/start_menu.lua
@@ -2,6 +2,7 @@
 local MENU = require 'infra.menu'
 local INPUT = require 'infra.input'
 local CONTROLS = require 'infra.control'
+local PROFILE = require 'infra.profile'
 local HudView = require 'domain.view.hudview'
 
 local state = {}
@@ -10,6 +11,7 @@ local state = {}
 
 local _width, _height
 local _menu_view
+local _menu_context
 local _font
 
 --LOCAL FUNCTIONS--
@@ -30,6 +32,7 @@ end
 
 function state:enter ()
   _menu_view:addElement("HUD", nil, "menu_view")
+  _menu_context = "START_MENU"
   CONTROLS.setMap {
     PRESS_ACTION_1 = MENU.confirm,
     PRESS_SPECIAL  = MENU.cancel,
@@ -46,18 +49,38 @@ end
 
 function state:update (dt)
   INPUT.update()
-  if MENU.begin("START_MENU", 80*4, _height / 2) then
-    if MENU.item("New route") then
-      SWITCHER.switch(GS.PLAY)
-    end
-    if MENU.item("Load route") then
-      print("Not implemented yet")
-    end
-    if MENU.item("Quit") then
-      love.event.quit()
+  if MENU.begin(_menu_context, 80*4, _height / 2, 3, 160) then
+    if _menu_context == "START_MENU" then
+      if MENU.item("New route") then
+        local route_id = PROFILE.newRoute()
+        SWITCHER.switch(GS.PLAY, route_id)
+      end
+      if MENU.item("Load route") then
+        _menu_context = "LOAD_LIST"
+      end
+      if MENU.item("Quit") then
+        love.event.quit()
+      end
+    elseif _menu_context == "LOAD_LIST" then
+      local savelist = PROFILE.getSaveList()
+      if #savelist > 0 then
+        for _,route_id in ipairs(savelist) do
+          if MENU.item(route_id) then
+            SWITCHER.switch(GS.PLAY, PROFILE.loadRoute(route_id))
+          end
+        end
+      else
+        if MENU.item("[ NO DATA ]") then
+          _menu_context = "START_MENU"
+        end
+      end
     end
   else
-    love.event.quit()
+    if _menu_context == "START_MENU" then
+      love.event.quit()
+    elseif _menu_context == "LOAD_LIST" then
+      _menu_context = "START_MENU"
+    end
   end
   MENU.finish()
   _title()

--- a/game/infra/profile.lua
+++ b/game/infra/profile.lua
@@ -1,0 +1,82 @@
+
+local json = require 'dkjson'
+local IDGenerator = require 'common.idgenerator'
+local RUNFLAGS = require 'infra.runflags'
+
+-- CONSTANTS --
+local SAVEDIR = "_savedata/"
+local PROFILE_FILENAME = SAVEDIR.."profile"
+local METABASE = { next_id = 1, save_list = {} }
+
+-- HELPERS
+local filesystem = love.filesystem
+
+-- LOCALS --
+local PROFILE = {}
+local _id_generator
+local _metadata
+
+local function _cleanSlate ()
+  local savedir = filesystem.getSaveDirectory()
+  print("CLEAR FLAG SET. DELETING ALL SAVE DATA.")
+  for _,filename in ipairs(filesystem.getDirectoryItems(SAVEDIR)) do
+    print(("Removing: %s"):format(filename))
+    filesystem.remove(SAVEDIR..filename)
+  end
+end
+
+local function _newProfile()
+  filesystem.createDirectory(SAVEDIR)
+  local file, err = filesystem.newFile(PROFILE_FILENAME, "w")
+  assert(file, err)
+  local encoded = json.encode(METABASE)
+  file:write(encoded)
+  return file:close()
+end
+
+-- METHODS --
+function PROFILE.init()
+  if RUNFLAGS.CLEAR then _cleanSlate() end
+  -- check if profile exists
+  if not filesystem.exists(PROFILE_FILENAME) then _newProfile() end
+
+  -- load profile
+  local filedata, err = filesystem.newFileData(PROFILE_FILENAME)
+  assert(filedata, err)
+  _metadata = json.decode(filedata:getString())
+  _id_generator = IDGenerator(_metadata.next_id)
+end
+
+function PROFILE.save()
+  local file, err = filesystem.newFile(PROFILE_FILENAME, "w")
+  assert(file, err)
+  file:write(json.encode(_metadata))
+  return file:close()
+end
+
+function PROFILE.loadRoute(route_id)
+  local filedata, err = filesystem.newFileData(SAVEDIR..route_id)
+  assert(filedata, err)
+  return json.decode(filedata:getString())
+end
+
+function PROFILE.saveRoute(route_data)
+  local file, err = filesystem.newFile(SAVEDIR..route_data.route_id, "w")
+  assert(file, err)
+  table.insert(_metadata.save_list, route_data.route_id)
+  file:write(json.encode(route_data))
+  return file:close()
+end
+
+function PROFILE.newRoute()
+  local id = ("route%s"):format(_id_generator.newID())
+  _metadata.next_id = _id_generator.getNextID()
+  print(("Generating %s..."):format(id))
+  return route_id
+end
+
+function PROFILE.getSaveList ()
+  return _metadata.save_list
+end
+
+return PROFILE

--- a/game/infra/profile.lua
+++ b/game/infra/profile.lua
@@ -2,11 +2,12 @@
 local json = require 'dkjson'
 local IDGenerator = require 'common.idgenerator'
 local RUNFLAGS = require 'infra.runflags'
+local ROUTEBUILDER = require 'infra.routebuilder'
 
 -- CONSTANTS --
 local SAVEDIR = "_savedata/"
 local PROFILE_FILENAME = SAVEDIR.."profile"
-local METABASE = { next_id = 1, save_list = {} }
+local METABASE = { next_id = 1, save_list = {}, version = VERSION }
 
 -- HELPERS
 local filesystem = love.filesystem
@@ -17,7 +18,6 @@ local _id_generator
 local _metadata
 
 local function _cleanSlate ()
-  local savedir = filesystem.getSaveDirectory()
   print("CLEAR FLAG SET. DELETING ALL SAVE DATA.")
   for _,filename in ipairs(filesystem.getDirectoryItems(SAVEDIR)) do
     print(("Removing: %s"):format(filename))
@@ -56,27 +56,54 @@ end
 
 function PROFILE.loadRoute(route_id)
   local filedata, err = filesystem.newFileData(SAVEDIR..route_id)
+  local route_data = json.decode(filedata:getString())
+  -- delete save from list
+  _metadata.save_list[route_data.route_id] = nil
   assert(filedata, err)
-  return json.decode(filedata:getString())
+  return route_data
 end
 
 function PROFILE.saveRoute(route_data)
   local file, err = filesystem.newFile(SAVEDIR..route_data.route_id, "w")
   assert(file, err)
-  table.insert(_metadata.save_list, route_data.route_id)
+  -- add save to list
+  -- Not that since we have the route's data in this scope, we can
+  -- put a header in a profile header instead of just the value `true`.
+  _metadata.save_list[route_data.route_id] = {
+    charname = route_data.charname
+  }
   file:write(json.encode(route_data))
   return file:close()
 end
 
 function PROFILE.newRoute()
-  local id = ("route%s"):format(_id_generator.newID())
+  local route_id = ("route%s"):format(_id_generator.newID())
+  local route_data = ROUTEBUILDER.build(route_id)
   _metadata.next_id = _id_generator.getNextID()
-  print(("Generating %s..."):format(id))
-  return route_id
+  print(("Generating %s..."):format(route_id))
+  print(("Seed: %d"):format(route_data.seed))
+  return route_data
 end
 
 function PROFILE.getSaveList ()
   return _metadata.save_list
 end
+
+-- NOTE TO SELF:
+-- Add a quit method that deletes saves that are not on the profile's save_list.
+-- This means that when you load a file, and you don't save it, it is lost
+-- forever once the program quits. This would be an easy way to implement
+-- permadeath. Also if you quit without saving, you lose your savefle.
+-- BUT! If the game crashes, you keep your last save.
+function PROFILE.quit()
+  local save_list = _metadata.save_list
+  for _,filename in ipairs(filesystem.getDirectoryItems(SAVEDIR)) do
+    if filename ~= PROFILE_FILENAME and not save_list[filename] then
+      print(("Removing unsaved file: %s"):format(filename))
+      filesystem.remove(SAVEDIR..filename)
+    end
+  end
+end
+
 
 return PROFILE

--- a/game/infra/routebuilder.lua
+++ b/game/infra/routebuilder.lua
@@ -1,0 +1,17 @@
+
+local ROUTEBUILDER = {}
+
+function ROUTEBUILDER.build (route_id)
+  return {
+    version = VERSION,
+    charname = "Banana",
+    route_id = route_id,
+    next_id = 1,
+    seed = tonumber(tostring(os.time()):sub(-7):reverse()),
+    actors = {},
+    sectors = {},
+  }
+end
+
+return ROUTEBUILDER
+

--- a/game/infra/routebuilder.lua
+++ b/game/infra/routebuilder.lua
@@ -1,4 +1,6 @@
 
+local RANDOM = require 'common.random'
+
 local ROUTEBUILDER = {}
 
 function ROUTEBUILDER.build (route_id)
@@ -7,7 +9,7 @@ function ROUTEBUILDER.build (route_id)
     charname = "Banana",
     route_id = route_id,
     next_id = 1,
-    seed = tonumber(tostring(os.time()):sub(-7):reverse()),
+    seed = RANDOM.generateSeed(),
     actors = {},
     sectors = {},
   }

--- a/game/infra/runflags.lua
+++ b/game/infra/runflags.lua
@@ -5,7 +5,10 @@ local _flags = {}
 function RUNFLAGS.init(arg)
   for _, runflag in ipairs(arg) do
     if runflag:match("^%-") then
-      _flags[runflag:match("[^%-]+"):upper()] = true
+      local flagname = runflag:match("%-(%w+)")
+      local value = runflag:match("=(.+)")
+      value = tonumber(value) or value or true
+      _flags[flagname:upper()] = value
     end
   end
   RUNFLAGS.init = function () end

--- a/game/infra/runflags.lua
+++ b/game/infra/runflags.lua
@@ -1,0 +1,16 @@
+
+local RUNFLAGS = {}
+local _flags = {}
+
+function RUNFLAGS.init(arg)
+  for _, runflag in ipairs(arg) do
+    if runflag:match("^%-") then
+      _flags[runflag:match("[^%-]+"):upper()] = true
+    end
+  end
+  RUNFLAGS.init = function () end
+end
+
+return setmetatable(RUNFLAGS, {
+  __index = function (t, k) return _flags[k] end
+})

--- a/game/main.lua
+++ b/game/main.lua
@@ -34,6 +34,9 @@ GS = {
 -- GAMESTATE SWITCHER
 SWITCHER = require 'infra.switcher'
 
+local PROFILE = require 'infra.profile'
+local RUNFLAGS = require 'infra.runflags'
+
 ------------------
 --LÖVE FUNCTIONS--
 ------------------
@@ -42,9 +45,11 @@ function love.load(arg)
 
     Setup.config() --Configure your game
 
+    RUNFLAGS.init(arg)
 
     SWITCHER.init() --Overwrites love callbacks to call Gamestate as well
 
+    PROFILE.init() -- initializes save & load system
 
     --[[
         Setup support for multiple resolutions. Res.init() Must be called after Gamestate.registerEvents()
@@ -59,4 +64,5 @@ end
 
 function love.quit()
   imgui.ShutDown();
+  PROFILE.save()
 end

--- a/game/setup.lua
+++ b/game/setup.lua
@@ -9,6 +9,8 @@ local setup = {}
 --Set game's global variables, random seed, window configuration and anything else needed
 function setup.config()
 
+    VERSION = "0.0.4"
+
     --RANDOM SEED--
     love.math.setRandomSeed( os.time() )
 


### PR DESCRIPTION
This adds a profile module in `infra/profile.lua` and a runflags module in `infra/runflags.lua`.

The `PROFILE` module takes care of saving the game's metadata and its savefiles. Its `save` and `init` functions are for loading/creating the metadata, currently saved in a json file in your user's save directory. The `saveRoute` and `loadRoute` functions are for saving/loading individual routes. There is also a `newRoute` function, which currently only generates a route id.

We have no savefiles yet, though. This PR is just for adding a save/load system.

Also, for debugging purposes, I added runflags. You can run the game using `love` directly and pass parametres like `-clear` or `--clear` and they are stored in all caps in `RUNFLAGS.CLEAR`. Since we have a visual dev mode editor already, I thought it might be a tad... rustic. But it makes deleting savefiles and profiles easy, and this is why I added them with this PR. This could be used to allow dev mode too, maybe. I don't know. Check it out.