### PR TITLE
Add working placeholder save & quit feature

### DIFF
--- a/game/gamestates/play.lua
+++ b/game/gamestates/play.lua
@@ -6,6 +6,7 @@ local DB = require 'database'
 local DIR = require 'domain.definitions.dir'
 local INPUT = require 'infra.input'
 local CONTROL = require 'infra.control'
+local PROFILE = require 'infra.profile'
 local GUI = require 'debug.gui'
 
 local Route = require 'domain.route'
@@ -112,7 +113,7 @@ function state:init()
   end
 end
 
-function state:enter()
+function state:enter(pre, route_data)
 
   _route = Route()
 
@@ -132,6 +133,10 @@ function state:enter()
 
   Signal.register("move", _makeSignalHandler(_moveActor))
   Signal.register("widget_1", _makeSignalHandler(_usePrimaryAction))
+  Signal.register("pause", function ()
+    PROFILE.saveRoute(route_data)
+    love.event.quit()
+  end)
   CONTROL.setMap(SIGNALS)
 
   _gui = GUI(_sector_view)

--- a/game/gamestates/start_menu.lua
+++ b/game/gamestates/start_menu.lua
@@ -63,7 +63,7 @@ function state:update (dt)
       end
     elseif _menu_context == "LOAD_LIST" then
       local savelist = PROFILE.getSaveList()
-      if #savelist > 0 then
+      if next(savelist) then
         for route_id, route_header in pairs(savelist) do
           if MENU.item(route_header.charname) then
             SWITCHER.switch(GS.PLAY, PROFILE.loadRoute(route_id))

--- a/game/main.lua
+++ b/game/main.lua
@@ -64,5 +64,5 @@ end
 
 function love.quit()
   imgui.ShutDown();
-  PROFILE.save()
+  PROFILE.quit()
 end


### PR DESCRIPTION
This makes saving & quit during gameplay possible. It also makes sure your saved routes show on the `Load Route` option on the `START MENU`. Of course, this still saves nothing of use yet, but it is easy to improve upon this.

I also noticed a visual bug with the scrolling in the `infra/menu.lua` module on the `Load Route` menu option. Will fix it in a different PR.