### PR TITLE
Make it possible to save cards

### DIFF
--- a/game/domain/actor.lua
+++ b/game/domain/actor.lua
@@ -1,7 +1,8 @@
 
 local GameElement = require 'domain.gameelement'
 local ACTION      = require 'domain.action'
-local CARD        = require 'domain.card'
+local Card        = require 'domain.card'
+local RANDOM      = require 'common.random'
 
 local Actor = Class{
   __includes = { GameElement }
@@ -31,6 +32,13 @@ function Actor:loadState(state)
   self.actions = state.actions
   self.body_id = state.body_id
   self:setId(state.id)
+  self.hand_limit = state.hand_limit
+  self.hand = {}
+  for _,card_state in ipairs(state.hand) do
+    local card = Card(card_state.specname)
+    card:loadState(card_state)
+    table.insert(self.hand, card)
+  end
 end
 
 function Actor:saveState()
@@ -40,6 +48,12 @@ function Actor:saveState()
   state.actions = self.actions
   state.body_id = self.body_id
   state.id = self.id
+  state.hand_limit = self.hand_limit
+  state.hand = {}
+  for _,card in ipairs(self.hand) do
+    local card_state = card:saveState()
+    table.insert(state.hand, card_state)
+  end
   return state
 end
 
@@ -95,10 +109,10 @@ function Actor:drawCard()
 
   --TODO: Change this so actor draws from his buffer
   local card
-  if love.math.random() >.5 then
-    card = CARD("dummy")
+  if RANDOM.interval() >.5 then
+    card = Card("dummy")
   else
-    card = CARD("dummy2")
+    card = Card("dummy2")
   end
   table.insert(self.hand, card)
   Signal.emit("actor_draw", self, card)

--- a/game/domain/gameelement.lua
+++ b/game/domain/gameelement.lua
@@ -23,6 +23,15 @@ function GameElement:getId()
   return self.id
 end
 
+function GameElement:loadState(state)
+end
+
+function GameElement:saveState()
+  local state = {}
+  state.specname = self.specname
+  return state
+end
+
 function GameElement:getSpec(key)
   return DB.loadSpec(self.spectype, self.specname)[key]
 end

--- a/game/infra/routebuilder.lua
+++ b/game/infra/routebuilder.lua
@@ -15,7 +15,9 @@ local function _generatePlayerActorData(idgenerator, body_id)
       IDLE = true,
       MOVE = true,
       PRIMARY = "DRAW"
-    }
+    },
+    hand_limit = 7,
+    hand = {}
   }
 end
 


### PR DESCRIPTION
fix #207 

I added the methods of `saveState` and `loadState` to `GameElement` because this way there is a standard way of saving elements that are specname only, like cards, without having to rewrite the method again.

Also @rilifon please make sure to use the random module in `common.random` because it uses the game's RNG. Avoid calling `love.math.random` explicitly, as it does not change the RNG's state, and thus cannot be reproduced. But it's also my fault for not naming the module and its methods in a good/intuitive way. I will open an issue on that.