### PR TITLE
Store only type in tiles

### DIFF
--- a/game/domain/transformers/helpers/sectorgrid.lua
+++ b/game/domain/transformers/helpers/sectorgrid.lua
@@ -77,22 +77,5 @@ function SectorGrid:instance(obj, w, h, mw, mh)
 
 end
 
-function SectorGrid:from(matrix, mw, mh)
-  -- when we implement walls and other tiles, we'll need to update this method
-  local h = #matrix
-  local w = #matrix[1]
-  mw = mw or 0
-  mh = mh or 0
-  local grid = SectorGrid(w, h, mw, mh)
-  for i = 1, h do
-    for j = 1, w do
-      local tile = matrix[i][j]
-      if tile then tile = tile.type end
-      grid.set(j, i, tile)
-    end
-  end
-  return grid
-end
-
 return SectorGrid
 

--- a/game/domain/view/sectorview.lua
+++ b/game/domain/view/sectorview.lua
@@ -1,7 +1,16 @@
+
+local SCHEMATICS  = require 'domain.definitions.schematics'
+local COLORS      = require 'domain.definitions.colors'
+
 local TILE_W = 80
 local TILE_H = 80
 local HALF_W = 10
 local HALF_H = 6
+
+local TILE_COLORS = {
+  [SCHEMATICS.FLOOR] = COLORS.FLOOR1,
+  [SCHEMATICS.EXIT] = COLORS.EXIT,
+}
 
 local Cursor
 
@@ -56,7 +65,7 @@ function SectorView:draw()
           local x, y = j*TILE_W, i*TILE_H
           g.push()
           g.translate(x, y)
-          g.setColor(unpack(tile))
+          g.setColor(TILE_COLORS[tile.type])
           g.rectangle("fill", 0, 0, TILE_W, TILE_H)
           g.setColor(50, 50, 50)
           g.rectangle("fill", 0, TILE_H, TILE_W, TILE_H/4)


### PR DESCRIPTION
That is, make tiles no longer hold their color.

This makes all floor tiles look the same (no more checkered pattern!), but simplifies how saves are stored and loaded. Besides, `SectorGrid:from(tiles)` seems to be no longer necessary now. Should I remove it?

I am actually not 100% sure of this PR.