### PR TITLE
Make exits placement have better thresholds

### DIFF
--- a/game/domain/transformers/exits.lua
+++ b/game/domain/transformers/exits.lua
@@ -66,7 +66,7 @@ function transformer.process(sectorinfo, params)
   end
 
   -- get a number of random possible exits from that list
-  (function()
+  local function chooseExits()
     local N = #exits_specs -- max number of exits
     for edx = 1, N do
       local i, j
@@ -76,7 +76,6 @@ function transformer.process(sectorinfo, params)
           -- if there is only one last possible exit, check it:
           i, j = unpack(possible_exits[1])
           -- if it's not a good position, tough luck, break it up
-          -- this is why this has to be a lambda
           if not _isPossibleExit(sectorgrid, j, i) then return end
         else
           -- if there are many possible exits, get a random one:
@@ -98,8 +97,9 @@ function transformer.process(sectorinfo, params)
       table.insert(chosen_exits, exit)
       sectorgrid.set(j, i, SCHEMATICS.EXIT)
     end
-  end)()
+  end
 
+  chooseExits()
   sectorinfo.exits = chosen_exits
   return sectorinfo
 end

--- a/game/domain/transformers/exits.lua
+++ b/game/domain/transformers/exits.lua
@@ -100,7 +100,6 @@ function transformer.process(sectorinfo, params)
     end
   end)()
 
-  print("NO OF EXITS:", ("%d/%d"):format(#chosen_exits, #exits_specs))
   sectorinfo.exits = chosen_exits
   return sectorinfo
 end

--- a/game/domain/transformers/exits.lua
+++ b/game/domain/transformers/exits.lua
@@ -20,16 +20,23 @@ function transformer.process(sectorinfo, params)
   local _sectorgrid = sectorinfo.grid
   local _exits = params.exits
 
+
+  local function isPossibleExit(x, y)
+    local f = SCHEMATICS.FLOOR
+    for dx = -1, 1, 1 do
+      for dy = -1, 1, 1 do
+        local tx, ty = dx + x, dy + y
+        if _sectorgrid.get(tx, ty) ~= f then return false end
+      end
+    end
+    return true
+  end
+
   local function getPossibleExits()
     local possible_exits = {}
     for x, y, tile in _sectorgrid.iterate() do
-      if tile == SCHEMATICS.FLOOR then
-        if _sectorgrid.get(x + 1, y) == SCHEMATICS.FLOOR and
-           _sectorgrid.get(x - 1, y) == SCHEMATICS.FLOOR and
-           _sectorgrid.get(x, y + 1) == SCHEMATICS.FLOOR and
-           _sectorgrid.get(x, y - 1) == SCHEMATICS.FLOOR then
-          table.insert(possible_exits, {y, x})
-        end
+      if isPossibleExit(x, y) then
+        table.insert(possible_exits, {y, x})
       end
     end
     return possible_exits

--- a/game/domain/transformers/exits.lua
+++ b/game/domain/transformers/exits.lua
@@ -16,18 +16,37 @@ transformer.schema = {
   },
 }
 
-local function _isPossibleExit(grid, x, y)
+local FLOOR_THRESHOLD = 2
+local EXIT_THRESHOLD = 5
+
+local function _hasSpaceForExit(grid, x, y)
   local f = SCHEMATICS.FLOOR
-  local e = SCHEMATICS.EXIT
-  for dx = -1, 1, 1 do
-    for dy = -1, 1, 1 do
+  for dx = -FLOOR_THRESHOLD, FLOOR_THRESHOLD do
+    for dy = -FLOOR_THRESHOLD, FLOOR_THRESHOLD do
       local tx, ty = dx + x, dy + y
       local tile = grid.get(tx, ty)
       -- verify it's a position surrounded by floors and not a single exit
-      if tile ~= f or tile == e then return false end
+      if tile ~= f then return false end
     end
   end
   return true
+end
+
+local function _hasNoExitNearby(grid, x, y)
+  local e = SCHEMATICS.EXIT
+  for dx = -EXIT_THRESHOLD, EXIT_THRESHOLD, 1 do
+    for dy = -EXIT_THRESHOLD, EXIT_THRESHOLD, 1 do
+      local tx, ty = dx + x, dy + y
+      local tile = grid.get(tx, ty)
+      -- verify it's a position surrounded by floors and not a single exit
+      if tile == e then return false end
+    end
+  end
+  return true
+end
+
+local function _isPossibleExit(grid, x, y)
+  return _hasSpaceForExit(grid, x, y) and _hasNoExitNearby(grid, x, y)
 end
 
 function transformer.process(sectorinfo, params)
@@ -81,6 +100,7 @@ function transformer.process(sectorinfo, params)
     end
   end)()
 
+  print("NO OF EXITS:", ("%d/%d"):format(#chosen_exits, #exits_specs))
   sectorinfo.exits = chosen_exits
   return sectorinfo
 end

--- a/game/domain/transformers/exits.lua
+++ b/game/domain/transformers/exits.lua
@@ -16,54 +16,72 @@ transformer.schema = {
   },
 }
 
-function transformer.process(sectorinfo, params)
-  local _sectorgrid = sectorinfo.grid
-  local _exits = params.exits
-
-
-  local function isPossibleExit(x, y)
-    local f = SCHEMATICS.FLOOR
-    for dx = -1, 1, 1 do
-      for dy = -1, 1, 1 do
-        local tx, ty = dx + x, dy + y
-        if _sectorgrid.get(tx, ty) ~= f then return false end
-      end
+local function _isPossibleExit(grid, x, y)
+  local f = SCHEMATICS.FLOOR
+  local e = SCHEMATICS.EXIT
+  for dx = -1, 1, 1 do
+    for dy = -1, 1, 1 do
+      local tx, ty = dx + x, dy + y
+      local tile = grid.get(tx, ty)
+      -- verify it's a position surrounded by floors and not a single exit
+      if tile ~= f or tile == e then return false end
     end
-    return true
   end
+  return true
+end
 
-  local function getPossibleExits()
-    local possible_exits = {}
-    for x, y, tile in _sectorgrid.iterate() do
-      if isPossibleExit(x, y) then
+function transformer.process(sectorinfo, params)
+  local sectorgrid = sectorinfo.grid
+  local exits_specs = params.exits
+
+  local possible_exits = {}
+  local chosen_exits = {}
+
+  -- construct list of possible exits
+  do
+    for x, y, tile in sectorgrid.iterate() do
+      if _isPossibleExit(sectorgrid, x, y) then
         table.insert(possible_exits, {y, x})
       end
     end
-    return possible_exits
   end
 
-  local function getRandomExits(possible_exits)
-    local N = #_exits
-    local exits = {}
-    for i = 1, N do
-      local idx = RANDOM.generate(1, #possible_exits)
-      table.insert(exits, {
-        pos = possible_exits[idx],
-        target_specname = _exits[i].target_specname
-      })
+  -- get a number of random possible exits from that list
+  (function()
+    local N = #exits_specs -- max number of exits
+    for edx = 1, N do
+      local i, j
+      repeat
+        local COUNT = #possible_exits
+        if COUNT == 1 then
+          -- if there is only one last possible exit, check it:
+          i, j = unpack(possible_exits[1])
+          -- if it's not a good position, tough luck, break it up
+          -- this is why this has to be a lambda
+          if not _isPossibleExit(sectorgrid, j, i) then return end
+        else
+          -- if there are many possible exits, get a random one:
+          local idx = RANDOM.generate(1, COUNT)
+          i, j = unpack(possible_exits[idx])
+          -- remove found position from list of possible exits
+          possible_exits[idx] = possible_exits[COUNT]
+          possible_exits[COUNT] = nil
+        end
+        -- repeat until you find a position that:
+        -- > is not an exit or around another exit
+      until _isPossibleExit(sectorgrid, j, i)
+      local exit = {
+        pos = {i, j},
+        target_specname = exits_specs[edx].target_specname
+      }
+      -- add exit info to sectorinfo
+      -- and set and exit tile on the sectorgrid
+      table.insert(chosen_exits, exit)
+      sectorgrid.set(j, i, SCHEMATICS.EXIT)
     end
-    return exits
-  end
+  end)()
 
-  local function setExits(exits)
-    for _,exit in ipairs(exits) do
-      local x, y = exit.pos[2], exit.pos[1]
-      _sectorgrid.set(x, y, SCHEMATICS.EXIT)
-    end
-  end
-
-  sectorinfo.exits = getRandomExits(getPossibleExits())
-  setExits(sectorinfo.exits)
+  sectorinfo.exits = chosen_exits
   return sectorinfo
 end
 

--- a/game/tests/sector01.lua
+++ b/game/tests/sector01.lua
@@ -10,14 +10,17 @@ local _seed = RANDOM.generateSeed()
 RANDOM.setSeed(_seed)
 
 -- generation of sector, pretty straightforward
-local SPEC = DB.loadSpec("sector", "sector01")
-
 local function generate()
   local sectorinfo = {}
-  for _, specs in ipairs(SPEC.transformers) do
-    sectorinfo = TRANSFORMERS[specs.typename].process(sectorinfo, specs)
+
+  for _,transformer in DB.schemaFor('sector') do
+    local spec = DB.loadSpec("sector", "sector01")[transformer.id]
+    if spec then
+      sectorinfo = TRANSFORMERS[transformer.id].process(sectorinfo, spec)
+    end
   end
-  print(sectorinfo.grid)
+
+  print(sectorinfo.grid, sectorinfo.grid:getDim())
   return sectorinfo
 end
 


### PR DESCRIPTION
Makes exits only appear 5 tiles appart, in the middle of an area of 5x5 floor tiles. A little less performance, but it's still linear. I think. Not sure if these threshold values should be parametres.

Also fixes DB usage in the sector01 generation test. I cannot believe it was even working without that fix, but it was, albeit with unexpected results.

Should help with #227 
Might conflict with #235 