### PR TITLE
Add margin parametre to rooms

### DIFF
--- a/game/database/sector.json
+++ b/game/database/sector.json
@@ -1,7 +1,5 @@
 {
   "sector01":{
-    "width":8,
-    "margin-height":0,
     "encounters":{
       "max":30,
       "recipes":[{
@@ -30,7 +28,6 @@
       "w":40,
       "mw":2
     },
-    "margin-width":0,
     "exits":{
       "exits":[{
           "target_specname":"sector01"
@@ -79,7 +76,6 @@
     "connections":{
       "loops":24
     },
-    "height":8,
     "maze":{
       "double":false
     }

--- a/game/database/sector.json
+++ b/game/database/sector.json
@@ -20,7 +20,8 @@
       "tries":256,
       "maxh":9,
       "count":24,
-      "maxw":9
+      "maxw":9,
+      "rmar":1
     },
     "bootstrap":{
       "mh":2,

--- a/game/domain/transformers/rooms.lua
+++ b/game/domain/transformers/rooms.lua
@@ -11,6 +11,7 @@ transformer.schema = {
   { id = 'minh', name = "Minimum Height", type = 'integer', range = {2,32} },
   { id = 'maxw', name = "Maximum Width", type = 'integer', range = {2,32} },
   { id = 'maxh', name = "Maximum Height", type = 'integer', range = {2,32} },
+  { id = 'rmar', name = "Room Margin", type = 'integer', range = {1,32}},
   { id = 'count', name = "Room Count", type = 'integer', range = {1,32} },
   { id = 'tries', name = "Maximum Tries", type = 'integer', range = {1,1024} },
 }
@@ -25,7 +26,7 @@ function transformer.process(sectorinfo, params)
   local _minh = params.minh
   local _maxw = params.maxw
   local _maxh = params.maxh
-  local _rmargin = 3
+  local _rmargin = params.rmar
 
   -- room quantities
   local _count = params.count


### PR DESCRIPTION
For some reason room margins were fixed to 3 tiles. Now it's modifiable via devmode.

Also removed obsolete values in `sector.json`. Might conflict with #234 