### PR TITLE
Change input module to automated input calls

### DIFF
--- a/game/gamestates/card_select.lua
+++ b/game/gamestates/card_select.lua
@@ -1,6 +1,5 @@
 --MODULE FOR THE GAMESTATE: SELECTING A CARD IN HAND--
 
-local INPUT = require 'infra.input'
 local CONTROL = require 'infra.control'
 
 local state = {}
@@ -155,7 +154,6 @@ end
 function state:update(dt)
 
   if not DEBUG then
-    INPUT.update()
     MAIN_TIMER:update(dt)
     _sector_view:lookAt(_route.getControlledActor())
   end
@@ -177,10 +175,6 @@ function state:keypressed(key)
      return
   end
 
-  if not DEBUG then
-    INPUT.key_pressed(key)
-  end
-
   if key ~= "escape" then
       Util.defaultKeyPressed(key)
   end
@@ -196,10 +190,6 @@ function state:keyreleased(key)
     imgui.KeyReleased(key)
     if imgui.GetWantCaptureKeyboard() then
        return
-    end
-
-    if not DEBUG then
-        INPUT.key_released(key)
     end
 
 end

--- a/game/gamestates/pick_target.lua
+++ b/game/gamestates/pick_target.lua
@@ -7,7 +7,6 @@ local Sector = require 'domain.sector'
 local Body = require 'domain.body'
 local Actor = require 'domain.actor'
 local SectorView = require 'domain.view.sectorview'
-local INPUT = require 'infra.input'
 local ACTION = require 'domain.action'
 local CONTROL = require 'infra.control'
 
@@ -89,7 +88,6 @@ function state:update(dt)
 
   if not DEBUG then
     _sector_view:lookAtCursor()
-    INPUT.update()
   end
 
   Util.destroyAll()
@@ -109,10 +107,6 @@ function state:keypressed(key)
      return
   end
 
-  if not DEBUG then
-    INPUT.key_pressed(key)
-  end
-
   if key ~= "escape" then
       Util.defaultKeyPressed(key)
   end
@@ -128,10 +122,6 @@ function state:keyreleased(key)
     imgui.KeyReleased(key)
     if imgui.GetWantCaptureKeyboard() then
        return
-    end
-
-    if not DEBUG then
-        INPUT.key_released(key)
     end
 
 end

--- a/game/gamestates/start_menu.lua
+++ b/game/gamestates/start_menu.lua
@@ -1,6 +1,5 @@
 --MODULE FOR THE GAMESTATE: MAIN MENU--
 local MENU = require 'infra.menu'
-local INPUT = require 'infra.input'
 local CONTROLS = require 'infra.control'
 local PROFILE = require 'infra.profile'
 local HudView = require 'domain.view.hudview'
@@ -49,7 +48,6 @@ function state:leave ()
 end
 
 function state:update (dt)
-  INPUT.update()
   if MENU.begin(_menu_context, 80*4, _height / 2, 3, 160) then
     if _menu_context == "START_MENU" then
       if MENU.item("New route") then
@@ -90,14 +88,6 @@ end
 
 function state:draw ()
   Draw.allTables()
-end
-
-function state:keypressed(key)
-  INPUT.key_pressed(key)
-end
-
-function state:keyreleased(key)
-  INPUT.key_released(key)
 end
 
 function state:getView ()

--- a/game/gamestates/user_turn.lua
+++ b/game/gamestates/user_turn.lua
@@ -226,7 +226,7 @@ end
 function state:update(dt)
 
   if not DEBUG then
-    INPUT.update()
+    --INPUT.update()
     if _save_and_quit then return SWITCHER.pop("SAVE_AND_QUIT") end
     if _exit_sector then return SWITCHER.pop("EXIT_SECTOR") end
     _sector_view:lookAt(_route.getControlledActor())
@@ -256,7 +256,7 @@ function state:keypressed(key)
   end
 
   if not DEBUG then
-    INPUT.key_pressed(key)
+    --INPUT.key_pressed(key)
   end
 
   if key ~= "escape" then
@@ -277,7 +277,7 @@ function state:keyreleased(key)
     end
 
     if not DEBUG then
-        INPUT.key_released(key)
+        --INPUT.key_released(key)
     end
 
 end

--- a/game/gamestates/user_turn.lua
+++ b/game/gamestates/user_turn.lua
@@ -1,7 +1,6 @@
 --MODULE FOR THE GAMESTATE: PLAYER TURN--
 
 local DIR = require 'domain.definitions.dir'
-local INPUT = require 'infra.input'
 local ACTION = require 'domain.action'
 local CONTROL = require 'infra.control'
 
@@ -226,7 +225,6 @@ end
 function state:update(dt)
 
   if not DEBUG then
-    --INPUT.update()
     if _save_and_quit then return SWITCHER.pop("SAVE_AND_QUIT") end
     if _exit_sector then return SWITCHER.pop("EXIT_SECTOR") end
     _sector_view:lookAt(_route.getControlledActor())
@@ -255,10 +253,6 @@ function state:keypressed(key)
      return
   end
 
-  if not DEBUG then
-    --INPUT.key_pressed(key)
-  end
-
   if key ~= "escape" then
       Util.defaultKeyPressed(key)
   end
@@ -274,10 +268,6 @@ function state:keyreleased(key)
     imgui.KeyReleased(key)
     if imgui.GetWantCaptureKeyboard() then
        return
-    end
-
-    if not DEBUG then
-        --INPUT.key_released(key)
     end
 
 end

--- a/game/infra/input.lua
+++ b/game/infra/input.lua
@@ -42,55 +42,71 @@ local enabled_actions = {
 }
 
 -- Send actions to the control manager
-local function send_action (atype, aname)
+local function _sendAction (atype, aname)
   if not enabled_actions[aname] then return end
   local full_name = atype .. "_" .. aname
   controls.enqueue(full_name)
 end
 
-local function handle_press (key)
+local function _handlePress (key)
   local action_found = key_mapping[key]
   if not action_found then return end
-  send_action("PRESS", action_found)
+  _sendAction("PRESS", action_found)
 end
 
-local function handle_release (key)
+local function _handleRelease (key)
   local action_found = key_mapping[key]
   if not action_found then return end
-  send_action("RELEASE", action_found)
+  _sendAction("RELEASE", action_found)
 end
 
-local function handle_hold (key)
+local function _handleHold (key)
   local action_found = key_mapping[key]
   if not action_found then return end
-  send_action("HOLD", action_found)
+  _sendAction("HOLD", action_found)
 end
 
-local function check_held_keyboard_keys ()
+local function _checkHeldKeyboardKeys ()
   for key in pairs(key_mapping) do
     if love.keyboard.isDown(key) then
-      handle_hold(key)
+      _handleHold(key)
     end
   end
 end
 
 -- Public methods
-function input.key_pressed (key)
-  handle_press(key)
+function input.keyPressed (key)
+  _handlePress(key)
 end
 
-function input.key_released (key)
-  handle_release(key)
+function input.keyReleased (key)
+  _handleRelease(key)
 end
 
 function input.load ()
+  local key_released = love.keyreleased
+  local key_pressed = love.keypressed
+  local update = love.update
+  love.keyreleased = function(key)
+    if not DEBUG then input.keyReleased(key) end
+    key_released(key)
+  end
+  love.keypressed = function(key)
+    if not DEBUG then input.keyPressed(key) end
+    key_pressed(key)
+  end
+  love.update = function(dt)
+    if not DEBUG then input.update() end
+    update(dt)
+  end
+
   -- check saved input mapping
   -- load default values from a file here
 end
 
 function input.update ()
   -- check held controls
-  check_held_keyboard_keys()
+  _checkHeldKeyboardKeys()
   controls.update()
 end
 

--- a/game/main.lua
+++ b/game/main.lua
@@ -35,6 +35,7 @@ SWITCHER = require 'infra.switcher'
 
 local PROFILE = require 'infra.profile'
 local RUNFLAGS = require 'infra.runflags'
+local INPUT = require 'infra.input'
 
 ------------------
 --LÖVE FUNCTIONS--
@@ -58,6 +59,7 @@ function love.load(arg)
 
     require 'tests'
 
+    INPUT.load()
     SWITCHER.start(GS.START_MENU) --Jump to the inicial state
 
 end


### PR DESCRIPTION
This makes it unnecessary to require INPUT on any gamestate.
What is makes is wrap the `keypressed`, `keyreleased` and `update` functions in love to call input methods before executing the rest of the code. I'm assuming we want input updates as the first thing on each frame, right? Also it already checks the DEBUG global before executing them, so no worries there.