### PR TITLE
Widget selector

### DIFF
--- a/game/domain/definitions/dir.lua
+++ b/game/domain/definitions/dir.lua
@@ -1,6 +1,6 @@
 
 return {
-  'left', 'right', 'down', 'up',
+  'right', 'up', 'left', 'down',
   left = {0,-1},
   right = {0,1},
   down = {1,0},

--- a/game/domain/view/widgetview.lua
+++ b/game/domain/view/widgetview.lua
@@ -21,8 +21,15 @@ function WidgetView:init(route)
 
   self.route = route
   self.invisible = true
-  self.selected = 0
 
+end
+
+function WidgetView:select(idx)
+  self.selected = idx
+end
+
+function WidgetView:getSelected()
+  return self.selected
 end
 
 function WidgetView:show()
@@ -34,6 +41,7 @@ function WidgetView:show()
   if self.fadein or not self.invisible then
     return
   end
+  self.selected = false
   self.invisible = false
   self.enter = self.enter or { 0 }
   self.fadein = MAIN_TIMER:tween(
@@ -68,13 +76,19 @@ function WidgetView:draw()
   local enter = self.enter[1]
   g.push()
   g.translate(W/2, H/2 - 20)
-  local rot = pi/2 * (1 - enter)
+  local rot = pi/2 * (enter - 1)
   for i=0,3 do
-    local x,y = cos(rot + i/4*2*pi), sin(rot + i/4*2*pi)
+    g.push()
+    local x,y = cos(rot + i/4*2*pi), -sin(rot + i/4*2*pi)
+    g.translate(128*x, 128*y)
+    if self.selected == i+1 then
+      g.scale(1.5, 1.5)
+    end
     g.setColor(80, 10, 50, enter*100)
-    g.circle("fill", 128*x+8, 128*y+8, 32)
+    g.circle("fill", 8, 8, 32)
     g.setColor(20, 100, 80, enter*255)
-    g.circle("fill", 128*x, 128*y, 32)
+    g.circle("fill", 0, 0, 32)
+    g.pop()
   end
   g.pop()
 end

--- a/game/domain/view/widgetview.lua
+++ b/game/domain/view/widgetview.lua
@@ -66,7 +66,7 @@ function WidgetView:draw()
   local cos, sin, pi = math.cos, math.sin, math.pi
   local enter = self.enter[1]
   g.push()
-  g.translate(W/2, H/2)
+  g.translate(W/2, H/2 - 20)
   local rot = pi/2 * (1 - enter)
   for i=0,3 do
     local x,y = cos(rot + i/4*2*pi), sin(rot + i/4*2*pi)

--- a/game/domain/view/widgetview.lua
+++ b/game/domain/view/widgetview.lua
@@ -67,10 +67,12 @@ function WidgetView:draw()
   local enter = self.enter[1]
   g.push()
   g.translate(W/2, H/2)
-  g.setColor(20, 100, 80, enter*100)
-  g.rotate(pi/2 * (1 - enter))
+  local rot = pi/2 * (1 - enter)
   for i=0,3 do
-    local x,y = cos(i/4*2*pi), sin(i/4*2*pi)
+    local x,y = cos(rot + i/4*2*pi), sin(rot + i/4*2*pi)
+    g.setColor(80, 10, 50, enter*100)
+    g.circle("fill", 128*x+8, 128*y+8, 32)
+    g.setColor(20, 100, 80, enter*255)
     g.circle("fill", 128*x, 128*y, 32)
   end
   g.pop()

--- a/game/domain/view/widgetview.lua
+++ b/game/domain/view/widgetview.lua
@@ -21,6 +21,7 @@ function WidgetView:init(route)
 
   self.route = route
   self.invisible = true
+  self.selected = 0
 
 end
 

--- a/game/domain/view/widgetview.lua
+++ b/game/domain/view/widgetview.lua
@@ -1,0 +1,80 @@
+
+-- CONSTANTS -------------------------------------------------------------------
+
+local W, H
+
+-- LOCAL FUNCTION DECLARATIONS -------------------------------------------------
+
+-- WidgetView Class ------------------------------------------------------------
+
+local WidgetView = Class {
+  __includes = { ELEMENT }
+}
+
+-- CLASS METHODS ---------------------------------------------------------------
+
+function WidgetView:init(route)
+
+  ELEMENT.init(self)
+
+  W,H = love.graphics.getDimensions()
+
+  self.route = route
+  self.invisible = true
+
+end
+
+function WidgetView:show()
+  if self.fadeout then
+    MAIN_TIMER:cancel(self.fadeout)
+    self.fadeout = false
+    self.invisible = true
+  end
+  if self.fadein or not self.invisible then
+    return
+  end
+  self.invisible = false
+  self.enter = self.enter or { 0 }
+  self.fadein = MAIN_TIMER:tween(
+    0.5, self.enter, { 1 }, 'out-cubic',
+    function ()
+      self.fadein = false
+    end
+  )
+end
+
+function WidgetView:hide()
+  if self.fadein then
+    MAIN_TIMER:cancel(self.fadein)
+    self.fadein = false
+  end
+  if self.fadeout or self.invisible then
+    return
+  end
+  self.enter = self.enter or { 1 }
+  self.fadeout = MAIN_TIMER:tween(
+    0.5, self.enter, { 0 }, 'out-cubic',
+    function ()
+      self.fadeout = false
+      self.invisible = true
+    end
+  )
+end
+
+function WidgetView:draw()
+  local g = love.graphics
+  local cos, sin, pi = math.cos, math.sin, math.pi
+  local enter = self.enter[1]
+  g.push()
+  g.translate(W/2, H/2)
+  g.setColor(20, 100, 80, enter*100)
+  g.rotate(pi/2 * (1 - enter))
+  for i=0,3 do
+    local x,y = cos(i/4*2*pi), sin(i/4*2*pi)
+    g.circle("fill", 128*x, 128*y, 32)
+  end
+  g.pop()
+end
+
+return WidgetView
+

--- a/game/gamestates/card_select.lua
+++ b/game/gamestates/card_select.lua
@@ -8,7 +8,6 @@ local state = {}
 --LOCAL VARIABLES--
 
 local _route
-local _sector_view
 local _hand_view
 
 local _task
@@ -105,10 +104,9 @@ function state:init()
   end
 end
 
-function state:enter(_, route, sector_view, hand_view)
+function state:enter(_, route, hand_view)
 
   _route = route
-  _sector_view = sector_view
   _hand_view = hand_view
 
   _focus_index = 1
@@ -155,7 +153,6 @@ function state:update(dt)
 
   if not DEBUG then
     MAIN_TIMER:update(dt)
-    _sector_view:lookAt(_route.getControlledActor())
   end
 
   Util.destroyAll()

--- a/game/gamestates/pick_target.lua
+++ b/game/gamestates/pick_target.lua
@@ -87,6 +87,7 @@ end
 function state:update(dt)
 
   if not DEBUG then
+    MAIN_TIMER:update(dt)
     _sector_view:lookAtCursor()
   end
 

--- a/game/gamestates/user_turn.lua
+++ b/game/gamestates/user_turn.lua
@@ -31,10 +31,7 @@ local SIGNALS = {
   PRESS_CANCEL = {"wait"},
   PRESS_SPECIAL = {"start_card_selection"},
   PRESS_EXTRA = {"extra"},
-  PRESS_ACTION_1 = {"widget_1"},
-  PRESS_ACTION_2 = {"widget_2"},
-  PRESS_ACTION_3 = {"widget_3"},
-  PRESS_ACTION_4 = {"widget_4"},
+  PRESS_ACTION_1 = {"primary_action"},
   PRESS_PAUSE = {"pause"},
   PRESS_QUIT = {"quit"}
 }
@@ -58,7 +55,7 @@ local function _unlockState()
 end
 
 local function _showWidgets()
-  return not _next_action and INPUT.isDown('ACTION_3')
+  return not _next_action and INPUT.isDown('ACTION_2')
 end
 
 local function _changeToCardSelectScreen()
@@ -125,18 +122,6 @@ local function _usePrimaryAction()
   return _useAction('PRIMARY')
 end
 
-local function _useFirstWidget()
-  return _useAction('WIDGET_A')
-end
-
-local function _useSecondWidget()
-  --_view.widget:show()
-end
-
-local function _useThirdWidget()
-  return _useAction('WIDGET_C')
-end
-
 --- Receive a card index from player hands (between 1 and max-hand-size)
 local function _useCardByIndex(index)
   local card = _view.hand.hand[index]
@@ -189,10 +174,7 @@ function _registerSignals()
   Signal.register("confirm", _makeSignalHandler(_interact))
   Signal.register("start_card_selection",
                   _makeSignalHandler(_changeToCardSelectScreen))
-  Signal.register("widget_1", _makeSignalHandler(_usePrimaryAction))
-  Signal.register("widget_2", _makeSignalHandler(_useFirstWidget))
-  Signal.register("widget_3", _makeSignalHandler(_useSecondWidget))
-  Signal.register("widget_4", _makeSignalHandler(_useThirdWidget))
+  Signal.register("primary_action", _makeSignalHandler(_usePrimaryAction))
   Signal.register("pause", _makeSignalHandler(_saveAndQuit))
   CONTROL.setMap(_mapped_signals)
 end

--- a/game/gamestates/user_turn.lua
+++ b/game/gamestates/user_turn.lua
@@ -139,7 +139,7 @@ local function _interact()
       local widget = { 'A', 'B', 'C', 'D' }
       _useAction(('WIDGET_%s'):format(widget[selected]))
     end
-  else
+  elseif not _next_action then
     _exit_sector = true
   end
 end

--- a/game/gamestates/user_turn.lua
+++ b/game/gamestates/user_turn.lua
@@ -245,7 +245,7 @@ function state:update(dt)
 
     if _show_widgets then
       _view.widget:show()
-    elseif not _show_widgets then
+    else
       _view.widget:hide()
     end
     _show_widgets = false

--- a/game/infra/input.lua
+++ b/game/infra/input.lua
@@ -7,20 +7,24 @@ local controls = require 'infra.control'
 
 -- Translate keyboard keys to in-game controls
 local _key_mapping = {
-  f = "CONFIRM",
-  d = "CANCEL",
-  s = "SPECIAL",
-  a = "EXTRA",
-  r = "ACTION_1",
-  e = "ACTION_2",
-  w = "ACTION_3",
-  q = "ACTION_4",
-  up = "UP",
-  right = "RIGHT",
-  down = "DOWN",
-  left = "LEFT",
-  f8 = "QUIT",
-  escape = "PAUSE",
+  f       = "CONFIRM",
+  d       = "CANCEL",
+  s       = "SPECIAL",
+  a       = "EXTRA",
+  r       = "ACTION_1",
+  e       = "ACTION_2",
+  w       = "ACTION_3",
+  q       = "ACTION_4",
+  up      = "UP",
+  right   = "RIGHT",
+  down    = "DOWN",
+  left    = "LEFT",
+  k       = "UP",
+  l       = "RIGHT",
+  j       = "DOWN",
+  h       = "LEFT",
+  f8      = "QUIT",
+  escape  = "PAUSE",
 }
 
 -- List what action controls the game should check for

--- a/game/infra/input.lua
+++ b/game/infra/input.lua
@@ -45,6 +45,8 @@ local _enabled_actions = {
   PAUSE = true,
 }
 
+local _down = {}
+
 -- Send actions to the control manager
 local function _sendAction (atype, aname)
   if not _enabled_actions[aname] then return end
@@ -56,18 +58,21 @@ local function _handlePress (key)
   local action_found = _key_mapping[key]
   if not action_found then return end
   _sendAction("PRESS", action_found)
+  _down[action_found] = true
 end
 
 local function _handleRelease (key)
   local action_found = _key_mapping[key]
   if not action_found then return end
   _sendAction("RELEASE", action_found)
+  _down[action_found] = false
 end
 
 local function _handleHold (key)
   local action_found = _key_mapping[key]
   if not action_found then return end
   _sendAction("HOLD", action_found)
+  _down[action_found] = true
 end
 
 local function _checkHeldKeyboardKeys ()
@@ -85,6 +90,10 @@ end
 
 function input.keyReleased (key)
   _handleRelease(key)
+end
+
+function input.isDown (action)
+  return _down[action]
 end
 
 function input.init ()

--- a/game/infra/routebuilder.lua
+++ b/game/infra/routebuilder.lua
@@ -16,7 +16,10 @@ local function _generatePlayerActorData(idgenerator, body_id)
       IDLE = true,
       MOVE = true,
       PRIMARY = "DOUBLESHOOT",
-      WIDGET_A = "DRAW"
+      WIDGET_A = "HEAL",
+      WIDGET_B = "DRAW",
+      WIDGET_C = "DRAW",
+      WIDGET_D = "DRAW"
     },
     hand_limit = 7,
     hand = {}

--- a/game/main.lua
+++ b/game/main.lua
@@ -51,10 +51,9 @@ function love.load(arg)
 
     PROFILE.init() -- initializes save & load system
 
-    --[[
-        Setup support for multiple resolutions. Res.init() Must be called after Gamestate.registerEvents()
-        so it will properly call the draw function applying translations.
-    ]]
+    -- Setup support for multiple resolutions. Res.init() Must be called after
+    -- Gamestate.registerEvents() so it will properly call the draw function
+    -- applying translations.
     Res.init()
 
     require 'tests'


### PR DESCRIPTION
Added a simple menu for choosing widgets.

Controls in this PR become as follows:
+ ACTION_1 (R button) still launches the primary action of the actor
+ ACTION_2 (E button) will keep the widget menu open while held down
+ ACTION_3 (W button) and ACTION_4 (Q button) are unused for now

While the widget menu is visible, you can select a widget with the directionals, and confirm with the CONFIRM input (F button).

Try it out and tell me how it feels!