### PR TITLE
Card play design [take 1]

### DIFF
--- a/game/database/action.json
+++ b/game/database/action.json
@@ -17,7 +17,7 @@
     "operators":[],
     "effects":[{
         "typename":"draw_card",
-        "amount":2
+        "amount":1
       }]
   },
   "CHANGE_SECTOR":{
@@ -43,7 +43,7 @@
         "output":"target",
         "max-range":5
       }],
-    "cost":4,
+    "cost":6,
     "operators":[{
         "typename":"get_attribute",
         "output":"arcana",
@@ -60,6 +60,12 @@
         "target":"par:target",
         "amount":"val:amount"
       }]
+  },
+  "IDLE":{
+    "params":[],
+    "effects":[],
+    "operators":[],
+    "cost":1
   },
   "SHOOT":{
     "params":[{
@@ -81,16 +87,10 @@
         "op":"+",
         "typename":"integer_binop",
         "lhs":"val:attr",
-        "rhs":2,
+        "rhs":3,
         "output":"amount"
       }],
-    "cost":6
-  },
-  "IDLE":{
-    "params":[],
-    "effects":[],
-    "operators":[],
-    "cost":1
+    "cost":10
   },
   "DOUBLESHOOT":{
     "params":[{
@@ -109,11 +109,11 @@
     "effects":[{
         "typename":"deal_damage",
         "target":"par:target",
-        "amount":4
+        "amount":3
       },{
         "typename":"deal_damage",
         "target":"par:target2",
-        "amount":4
+        "amount":3
       }]
   },
   "DEBUG":{

--- a/game/database/action.json
+++ b/game/database/action.json
@@ -4,21 +4,36 @@
         "typename":"direction",
         "output":"pos"
       }],
+    "cost":3,
+    "operators":[],
     "effects":[{
         "typename":"move_to",
         "pos":"par:pos"
-      }],
-    "operators":[],
-    "cost":3
+      }]
   },
   "DRAW":{
     "params":[],
-    "cost":4,
-    "operators":[],
     "effects":[{
         "typename":"draw_card",
         "amount":1
+      }],
+    "operators":[],
+    "cost":4
+  },
+  "DEBUG":{
+    "params":[],
+    "cost":2,
+    "operators":[],
+    "effects":[{
+        "typename":"print",
+        "text":42
       }]
+  },
+  "IDLE":{
+    "params":[],
+    "cost":1,
+    "operators":[],
+    "effects":[]
   },
   "CHANGE_SECTOR":{
     "params":[{
@@ -28,22 +43,26 @@
         "typename":"direction",
         "output":"pos"
       }],
+    "cost":1,
+    "operators":[],
     "effects":[{
         "typename":"change_sector",
         "target_sector":"par:sector",
         "target_pos":"par:pos"
-      }],
-    "operators":[],
-    "cost":1
+      }]
   },
   "HEAL":{
     "params":[{
         "typename":"choose_target",
-        "filter":"BODY",
+        "max-range":5,
         "output":"target",
-        "max-range":5
+        "filter":"BODY"
       }],
-    "cost":6,
+    "effects":[{
+        "typename":"heal",
+        "target":"par:target",
+        "amount":"val:amount"
+      }],
     "operators":[{
         "typename":"get_attribute",
         "output":"arcana",
@@ -51,61 +70,24 @@
       },{
         "op":"+",
         "typename":"integer_binop",
-        "lhs":"val:arcana",
+        "output":"amount",
         "rhs":2,
-        "output":"amount"
+        "lhs":"val:arcana"
       }],
-    "effects":[{
-        "typename":"heal",
-        "target":"par:target",
-        "amount":"val:amount"
-      }]
-  },
-  "IDLE":{
-    "params":[],
-    "effects":[],
-    "operators":[],
-    "cost":1
-  },
-  "SHOOT":{
-    "params":[{
-        "typename":"choose_target",
-        "filter":"BODY",
-        "output":"target",
-        "max-range":5
-      }],
-    "effects":[{
-        "typename":"deal_damage",
-        "target":"par:target",
-        "amount":"val:amount"
-      }],
-    "operators":[{
-        "typename":"get_attribute",
-        "output":"attr",
-        "which":"ATH"
-      },{
-        "op":"+",
-        "typename":"integer_binop",
-        "lhs":"val:attr",
-        "rhs":3,
-        "output":"amount"
-      }],
-    "cost":10
+    "cost":6
   },
   "DOUBLESHOOT":{
     "params":[{
         "typename":"choose_target",
-        "filter":"BODY",
+        "max-range":10,
         "output":"target",
-        "max-range":10
+        "filter":"BODY"
       },{
         "typename":"choose_target",
-        "filter":"BODY",
+        "max-range":10,
         "output":"target2",
-        "max-range":10
+        "filter":"BODY"
       }],
-    "cost":12,
-    "operators":[],
     "effects":[{
         "typename":"deal_damage",
         "target":"par:target",
@@ -114,15 +96,41 @@
         "typename":"deal_damage",
         "target":"par:target2",
         "amount":3
-      }]
-  },
-  "DEBUG":{
-    "params":[],
-    "effects":[{
-        "typename":"print",
-        "text":42
       }],
     "operators":[],
-    "cost":2
+    "cost":12
+  },
+  "NEW_HAND":{
+    "params":[],
+    "cost":0,
+    "operators":[],
+    "effects":[{
+        "typename":"new_hand"
+      }]
+  },
+  "SHOOT":{
+    "params":[{
+        "typename":"choose_target",
+        "max-range":5,
+        "output":"target",
+        "filter":"BODY"
+      }],
+    "cost":10,
+    "operators":[{
+        "typename":"get_attribute",
+        "output":"attr",
+        "which":"ATH"
+      },{
+        "op":"+",
+        "typename":"integer_binop",
+        "output":"amount",
+        "rhs":3,
+        "lhs":"val:attr"
+      }],
+    "effects":[{
+        "typename":"deal_damage",
+        "target":"par:target",
+        "amount":"val:amount"
+      }]
   }
 }

--- a/game/database/card.json
+++ b/game/database/card.json
@@ -1,12 +1,17 @@
 {
-  "dummy":{
+  "cure":{
     "type":"ART",
-    "art_action":"SHOOT",
-    "name":"printf"
+    "art_action":"HEAL",
+    "name":"Cure"
   },
-  "dummy2":{
+  "draw":{
     "type":"ART",
     "art_action":"DRAW",
-    "name":"wilson"
+    "name":"Think"
+  },
+  "bolt":{
+    "type":"ART",
+    "art_action":"SHOOT",
+    "name":"Bolt"
   }
 }

--- a/game/domain/actor.lua
+++ b/game/domain/actor.lua
@@ -12,7 +12,7 @@ local BASE_ACTIONS = {
   IDLE = true,
   MOVE = true,
   INTERACT = true,
-  NEWHAND = true
+  NEW_HAND = true
 }
 
 function Actor:init(spec_name)
@@ -26,7 +26,7 @@ function Actor:init(spec_name)
   self.actions = setmetatable({ PRIMARY = "SHOOT" }, { __index = BASE_ACTIONS })
 
   self.hand = {}
-  self.hand_limit = 7
+  self.hand_limit = 5
 
 end
 
@@ -113,6 +113,14 @@ end
 
 function Actor:getHand()
   return self.hand
+end
+
+function Actor:isHandEmpty()
+  return #self.hand == 0
+end
+
+function Actor:getHandLimit()
+  return self.hand_limit
 end
 
 function Actor:tick()

--- a/game/domain/actor.lua
+++ b/game/domain/actor.lua
@@ -8,6 +8,13 @@ local Actor = Class{
   __includes = { GameElement }
 }
 
+local BASE_ACTIONS = {
+  IDLE = true,
+  MOVE = true,
+  INTERACT = true,
+  NEWHAND = true
+}
+
 function Actor:init(spec_name)
 
   GameElement.init(self, 'actor', spec_name)
@@ -16,12 +23,7 @@ function Actor:init(spec_name)
 
   self.body_id = nil
   self.cooldown = 10
-  self.actions = {
-    IDLE = true,
-    MOVE = true,
-    INTERACT = true,
-    PRIMARY = "SHOOT"
-  }
+  self.actions = setmetatable({ PRIMARY = "SHOOT" }, { __index = BASE_ACTIONS })
 
   self.hand = {}
   self.hand_limit = 7
@@ -30,7 +32,7 @@ end
 
 function Actor:loadState(state)
   self.cooldown = state.cooldown
-  self.actions = state.actions
+  self.actions = setmetatable(state.actions, { __index = BASE_ACTIONS })
   self.body_id = state.body_id
   self:setId(state.id)
   self.hand_limit = state.hand_limit

--- a/game/domain/actor.lua
+++ b/game/domain/actor.lua
@@ -167,10 +167,13 @@ function Actor:drawCard()
 
   --TODO: Change this so actor draws from his buffer
   local card
-  if RANDOM.generate() >.5 then
-    card = Card("dummy")
+  local roll = RANDOM.generate()
+  if roll > .5 then
+    card = Card("bolt")
+  elseif roll > .3 then
+    card = Card("cure")
   else
-    card = Card("dummy2")
+    card = Card("draw")
   end
   table.insert(self.hand, card)
   Signal.emit("actor_draw", self, card)

--- a/game/domain/effects/heal.lua
+++ b/game/domain/effects/heal.lua
@@ -12,3 +12,4 @@ function FX.process (actor, sector, params)
 end
 
 return FX
+

--- a/game/domain/effects/new_hand.lua
+++ b/game/domain/effects/new_hand.lua
@@ -1,0 +1,16 @@
+
+local FX = {}
+
+FX.schema = {
+}
+
+function FX.process (actor, sector, params)
+  if actor:isHandEmpty() then
+    for i = 1,actor:getHandLimit() do
+      actor:drawCard()
+    end 
+  end
+end
+
+return FX
+

--- a/game/domain/gameelement.lua
+++ b/game/domain/gameelement.lua
@@ -33,7 +33,9 @@ function GameElement:saveState()
 end
 
 function GameElement:getSpec(key)
-  return DB.loadSpec(self.spectype, self.specname)[key]
+  local spec = DB.loadSpec(self.spectype, self.specname)
+  assert(spec, ("Spec %s/%s not found"):format(self.spectype, self.specname))
+  return spec[key]
 end
 
 return GameElement

--- a/game/gamestates/user_turn.lua
+++ b/game/gamestates/user_turn.lua
@@ -144,6 +144,10 @@ local function _interact()
   end
 end
 
+local function _newHand()
+  _next_action = {'NEW_HAND'}
+end
+
 local function _saveAndQuit()
   _save_and_quit = true
 end
@@ -172,6 +176,7 @@ end
 function _registerSignals()
   Signal.register("move", _move)
   Signal.register("confirm", _makeSignalHandler(_interact))
+  Signal.register("extra", _newHand)
   Signal.register("start_card_selection",
                   _makeSignalHandler(_changeToCardSelectScreen))
   Signal.register("primary_action", _makeSignalHandler(_usePrimaryAction))

--- a/game/infra/input.lua
+++ b/game/infra/input.lua
@@ -36,6 +36,7 @@ local _enabled_actions = {
   CONFIRM = true,
   CANCEL = true,
   SPECIAL = true,
+  EXTRA = true,
   MENU = true,
   UP = true,
   RIGHT = true,

--- a/game/infra/routebuilder.lua
+++ b/game/infra/routebuilder.lua
@@ -13,9 +13,6 @@ local function _generatePlayerActorData(idgenerator, body_id)
     specname = "player",
     cooldown = 10,
     actions = {
-      IDLE = true,
-      MOVE = true,
-      INTERACT = true,
       PRIMARY = "DOUBLESHOOT",
       WIDGET_A = "HEAL",
       WIDGET_B = "DRAW",

--- a/game/infra/routebuilder.lua
+++ b/game/infra/routebuilder.lua
@@ -15,11 +15,8 @@ local function _generatePlayerActorData(idgenerator, body_id)
     actions = {
       PRIMARY = "DOUBLESHOOT",
       WIDGET_A = "HEAL",
-      WIDGET_B = "DRAW",
-      WIDGET_C = "DRAW",
-      WIDGET_D = "DRAW"
     },
-    hand_limit = 7,
+    hand_limit = 5,
     hand = {}
   }
 end


### PR DESCRIPTION
This PR experiments with one of the most recent ideas I had for card and hand dynamics in Backdoor.

The cardplay mechanic follows closely the one seen in deck-building card games such as Star Realms (I have it on my cell phone in case any of you want to check it out):

1. You have a deck which you are constantly adding cards to
2. On your "turn", you draw your whole hand, then play until you run out of cards

Adapting to Backdoor's context, it essentially means you can't draw another hand until you've finished the previous one. To avoid a bad hand locking the player, we just need to add an option to throw away cards (with possibly a compensation of sorts or not). This PR does not include this discard option (I can add it if you want to test it out).

**I chose the EXTRA (A button) input for the new "draw hand" action.**

Other things to consider:

1. For now, there are only three cards (damage, heal, and draw), so there isn't much to test
2. Ideally, you'd have a number of decks in the game, and you choose which to draw your hand from each time
3. There would also be a resource (card points?) you need to spend in order to draw a hand