### PR TITLE
Devmode's prototype improvements

### DIFF
--- a/game/database/schema/actor.lua
+++ b/game/database/schema/actor.lua
@@ -1,6 +1,7 @@
 
 return {
-  { id = 'extends', name = "Prototype", type = "enum", options = 'actor' },
+  { id = 'extends', name = "Prototype", type = "enum", options = 'actor',
+    optional = true },
   { id = 'behavior', name = "Behavior", type = "enum",
     options = {'player','random_walk'} },
   { id = 'ath', name = "ATH", type = "integer", range={0} },

--- a/game/database/schema/body.lua
+++ b/game/database/schema/body.lua
@@ -1,6 +1,7 @@
 
 return {
-  { id = 'extends', name = "Prototype", type = "enum", options = 'body' },
+  { id = 'extends', name = "Prototype", type = "enum", options = 'body',
+    optional = true},
   { id = 'hp', name = "Hit Points", type = "integer", range = {1,999} },
   { id = 'description', name = "Description", type = 'string' },
 }

--- a/game/debug/view/domain_list.lua
+++ b/game/debug/view/domain_list.lua
@@ -28,7 +28,7 @@ return function(domain_name, title)
   end
 
   local function newvalue(value, spec)
-    local new = spec or {}
+    local new = spec or DB.initSpec({}, domain_name)
     for _,key in DB.schemaFor(domain_name) do
       if key.type == 'list' then
         new[key.id] = new[key.id] or {}

--- a/game/debug/view/helpers/integer.lua
+++ b/game/debug/view/helpers/integer.lua
@@ -2,12 +2,11 @@
 local IMGUI = require 'imgui'
 
 return function (value, name, range)
-  local _, newvalue = IMGUI.InputInt(name, value, 1, 10)
+  local changed, newvalue = IMGUI.InputInt(name, value, 1, 10)
   if range then
-    return math.max(range[1],
-                    range[2] and math.min(range[2], newvalue) or newvalue)
-  else
-    return newvalue
+    newvalue = math.max(range[1],
+                        range[2] and math.min(range[2], newvalue) or newvalue)
   end
+  return changed, newvalue
 end
 

--- a/game/debug/view/helpers/string.lua
+++ b/game/debug/view/helpers/string.lua
@@ -2,9 +2,5 @@
 local IMGUI = require 'imgui'
 
 return function (value, name, range)
-
-  local _, newvalue = IMGUI.InputText(name, value, 64)
-
-  return newvalue
-
+  return IMGUI.InputText(name, value, 64)
 end

--- a/game/debug/view/input/common.lua
+++ b/game/debug/view/input/common.lua
@@ -17,7 +17,10 @@ function inputs.integer(spec, key)
   local inputInt = require 'debug.view.helpers.integer'
   return function (self)
     local value = spec[key.id] or (key.range or {0})[1]
-    spec[key.id] = inputInt(value, key.name, range)
+    local changed, newvalue = inputInt(value, key.name, range)
+    if changed then
+      spec[key.id] = newvalue
+    end
   end
 end
 
@@ -25,7 +28,10 @@ function inputs.string(spec, key)
   local inputStr = require 'debug.view.helpers.string'
   return function (self)
     local value = spec[key.id] or ""
-    spec[key.id] = inputStr(value, key.name)
+    local changed, newvalue = inputStr(value, key.name)
+    if changed then
+      spec[key.id] = newvalue
+    end
   end
 end
 

--- a/game/debug/view/input/enum.lua
+++ b/game/debug/view/input/enum.lua
@@ -7,30 +7,41 @@ local inputs = {}
 function inputs.enum(spec, key)
 
   -- Build option list from given array or from a database domain
-  local options = key.options
-  if type(options) == 'string' then
-    local domain = DB.loadDomain(options)
-    options = {}
+  local _options = key.options
+  if type(_options) == 'string' then
+    local domain = DB.loadDomain(_options)
+    _options = {}
     for k,v in pairs(domain) do
-      table.insert(options,k)
+      table.insert(_options,k)
     end
-    table.sort(options)
+    table.sort(_options)
   end
 
   -- Find the index of the currently assigned option
-  local current = 0
-  for i,option in ipairs(options) do
+  local _current = 1
+  for i,option in ipairs(_options) do
     if option == spec[key.id] then
-      current = i
+      _current = i
       break
     end
   end
 
+  local _active = not (not spec[key.id] and key.optional)
+
   return function(self)
-    local changed,value = IMGUI.Combo(key.name, current, options, #options, 10)
-    if changed then
-      current = value
-      spec[key.id] = options[value]
+    if key.optional then
+      _active = select(2, IMGUI.Checkbox("", _active))
+      IMGUI.SameLine()
+    end
+    if _active then
+      local changed,value = IMGUI.Combo(key.name, _current, _options, #_options,
+                                        10)
+      if changed then
+        _current = value
+        spec[key.id] = _options[value]
+      end
+    elseif key.optional then
+      IMGUI.Text(key.name)
     end
   end
 end

--- a/game/debug/view/input/init.lua
+++ b/game/debug/view/input/init.lua
@@ -16,7 +16,7 @@ end
 
 local function _invalid(spec, key)
   return function (self)
-    IMGUI.PushStyleColor("Text", 200, 100, 0, 255)
+    IMGUI.PushStyleColor("Text", 0.8, 0.6, 0, 1)
     IMGUI.Text(("Unknown input type: %s"):format(key.type))
     IMGUI.PopStyleColor(1)
   end

--- a/game/debug/view/input/reference.lua
+++ b/game/debug/view/input/reference.lua
@@ -67,11 +67,13 @@ inputs['value'] = function(spec, key, parent)
       end
     else
       if key.match == "integer" then
-        value = inputInt(value, key.name, key.range)
+        changed, value = inputInt(value, key.name, key.range)
       elseif key.match == 'string' then
-        value = inputStr(value, key.name)
+        changed, value = inputStr(value, key.name)
       end
-      spec[key.id] = value
+      if changed then
+        spec[key.id] = value
+      end
     end
 
     if key.match == 'integer' or key.match == 'string' then

--- a/game/debug/view/input/section.lua
+++ b/game/debug/view/input/section.lua
@@ -7,7 +7,7 @@ local _inputs = {}
 
 function _inputs.section(spec, key)
 
-  local schema = require('domain.' .. key.schema).schema
+  local schema = key.schema or require('domain.' .. key.schema).schema
   local backup = {}
 
   return function(self)

--- a/game/debug/view/specification_editor.lua
+++ b/game/debug/view/specification_editor.lua
@@ -6,13 +6,30 @@ local INPUT = require 'debug.view.input'
 return function(spec, domain_name, title, delete, rename, parent)
 
   local inputs = {}
+  local keys = {}
   for _,key in DB.schemaFor(domain_name) do
+    table.insert(keys, key)
     table.insert(inputs, INPUT(key.type, spec, key, parent))
   end
 
   return title .. " Editor", 2, function(self)
-    for _,input in ipairs(inputs) do
+    for i,input in ipairs(inputs) do
+      local pop = 0
+      local keyid = keys[i].id
+      local extended = rawget(spec, 'extends')
+      if extended and not rawget(spec, keyid) then
+        IMGUI.PushStyleColor("FrameBg", 0.8, 1, 0.9, 0.1)
+        pop = 1
+      end
       input(self)
+      if pop > 0 then
+        IMGUI.PopStyleColor(pop)
+      elseif extended and keyid ~= 'extends' then
+        IMGUI.SameLine()
+        if IMGUI.Button("Reset##"..keyid) then
+          rawset(spec, keyid, nil)
+        end
+      end
     end
     IMGUI.Spacing()
     IMGUI.Indent(360)


### PR DESCRIPTION
Close #256 

You can now erase the prototype field of body and actor specs, and also reset spec fields to their inherited value. A dark greenish grey bg color indicates a field has not been overwritten.

Please test for bugs!