### PR TITLE
Set padding and margin to devmode windows

### DIFF
--- a/game/debug/gui.lua
+++ b/game/debug/gui.lua
@@ -57,7 +57,7 @@ function GUI:push(viewname, ...)
   local width = MENU_WIDTH * size
   local x = tween.start(
     (length-size)*MENU_WIDTH,
-    length*MENU_WIDTH + #self.stack * 8,
+    8 + length*MENU_WIDTH + #self.stack * 8,
     5
   )
   self.stack[level] = {
@@ -65,12 +65,15 @@ function GUI:push(viewname, ...)
     draw = function (self)
       IMGUI.SetNextWindowPos(x(), 40, "Always")
       IMGUI.SetNextWindowSizeConstraints(width, 80, width, MENU_MAX_HEIGHT)
+      IMGUI.PushStyleVar("WindowPadding", 16, 16)
       local _,open = IMGUI.Begin(title, true,
-                                 { "NoCollapse", "AlwaysAutoResize" })
+                                 { "NoCollapse", "AlwaysAutoResize",
+                                 "AlwaysUseWindowPadding" })
       if open then
         open = not render(self)
       end
       IMGUI.End()
+      IMGUI.PopStyleVar()
       return open
     end
   }

--- a/game/debug/view/domain_list.lua
+++ b/game/debug/view/domain_list.lua
@@ -58,7 +58,9 @@ return function(domain_name, title)
     end
     IMGUI.Text(("All %ss:"):format(title))
     local changed
+    IMGUI.PushItemWidth(208)
     changed, selected = IMGUI.ListBox("", selected, list, list.n, 15)
+    IMGUI.PopItemWidth()
     if changed then
       self:push('specification_editor', domain[list[selected]], domain_name,
                 title, delete, rename)

--- a/game/debug/view/domain_list.lua
+++ b/game/debug/view/domain_list.lua
@@ -58,9 +58,7 @@ return function(domain_name, title)
     end
     IMGUI.Text(("All %ss:"):format(title))
     local changed
-    IMGUI.PushItemWidth(208)
     changed, selected = IMGUI.ListBox("", selected, list, list.n, 15)
-    IMGUI.PopItemWidth()
     if changed then
       self:push('specification_editor', domain[list[selected]], domain_name,
                 title, delete, rename)


### PR DESCRIPTION
All windows now have a padding, and they are offset to 8px to the right, so as to give a slight margin from the game's window's border. Looks nicer.