### PR TITLE
Refactor/timers + minor bug fixes

### DIFF
--- a/game/domain/actor.lua
+++ b/game/domain/actor.lua
@@ -161,6 +161,15 @@ function Actor:getBufferSize(which)
   end
 end
 
+function Actor:getBackBufferSize(which)
+  which = which or self.last_buffer
+  for i,card in ipairs(self.buffers[which]) do
+    if card == DEFS.DONE then
+      return #self.buffers[which] - i
+    end
+  end
+end
+
 function Actor:getHandLimit()
   return self.hand_limit
 end
@@ -250,4 +259,3 @@ function Actor:spendTime(n)
 end
 
 return Actor
-

--- a/game/domain/view/bufferpickerview.lua
+++ b/game/domain/view/bufferpickerview.lua
@@ -30,7 +30,7 @@ function BufferPickerView:init(actor)
   self.secondary_buffer_a = 0
 
   --Arrows
-  self.right_arrow_x = O_WIN_W/2 + 80
+  self.right_arrow_x = O_WIN_W/2 + 120
   self.left_arrow_x = O_WIN_W/2 - 80
   self.arrows_y = 3*O_WIN_H/4 - 10
 
@@ -74,7 +74,8 @@ function BufferPickerView:draw()
   --Draw current buffer number and remaining cards
   g.setColor(255, 255, 200)
   g.setFont(g.newFont(20))
-  g.print(("%d (%2d)"):format(self.select, size), c_x, c_y + i_h/2 + 40)
+  local back_buffer_size = self.actor:getBackBufferSize(self.select)
+  g.print(("%d (%2d) [%d]"):format(self.select, size, back_buffer_size), c_x, c_y + i_h/2 + 40)
 
   --Draw arrows
   g.setColor(239, 40, 103)
@@ -95,12 +96,13 @@ function BufferPickerView:moveSelection(dir)
 
     --Create changing-buffer effect
     self.is_changing_buffer = true
-    if self.timers["change_buffer"] then
-      MAIN_TIMER:cancel(self.timers["change_buffer"])
+    if self.timers[MAIN_TIMER]["change_buffer"] then
+      MAIN_TIMER:cancel(self.timers[MAIN_TIMER]["change_buffer"])
     end
     self.current_buffer_a, self.secondary_buffer_a = 0, 255
     self.current_buffer_x_mod, self.secondary_buffer_x_mod = x_mod_value, 0
-    self.timers["change_buffer"] = MAIN_TIMER:tween(.2,
+    self:addTimer("change_buffer", MAIN_TIMER, "tween",
+                                                    .2,
                                                     self,
                                                     {current_buffer_a = 255,
                                                      secondary_buffer_a = 0,
@@ -116,12 +118,13 @@ function BufferPickerView:moveSelection(dir)
 
     --Create changing-buffer effect
     self.is_changing_buffer = true
-    if self.timers["change_buffer"] then
-      MAIN_TIMER:cancel(self.timers["change_buffer"])
+    if self.timers[MAIN_TIMER]["change_buffer"] then
+      MAIN_TIMER:cancel(self.timers[MAIN_TIMER]["change_buffer"])
     end
     self.current_buffer_a, self.secondary_buffer_a = 0, 255
     self.current_buffer_x_mod, self.secondary_buffer_x_mod = -x_mod_value, 0
-    self.timers["change_buffer"] = MAIN_TIMER:tween(.2,
+    self:addTimer("change_buffer", MAIN_TIMER, "tween",
+                                                    .2,
                                                     self,
                                                     {current_buffer_a = 255,
                                                      secondary_buffer_a = 0,
@@ -145,7 +148,8 @@ end
 function expandArrows(b)
   local mod_value = 10
 
-  b.timers["arrow_effect"] = MAIN_TIMER:tween(.5,
+  b:addTimer("arrow_effect", MAIN_TIMER, "tween",
+                                              .5,
                                               b,
                                               {left_arrow_x = b.left_arrow_x - mod_value,
                                                right_arrow_x = b.right_arrow_x + mod_value},
@@ -158,7 +162,8 @@ end
 function closeArrows(b)
   local mod_value = 10
 
-  b.timers["arrow_effect"] = MAIN_TIMER:tween(.5,
+  b:addTimer("arrow_effect", MAIN_TIMER, "tween",
+                                              .5,
                                               b,
                                               {left_arrow_x = b.left_arrow_x + mod_value,
                                                right_arrow_x = b.right_arrow_x - mod_value},

--- a/game/domain/view/bufferpickerview.lua
+++ b/game/domain/view/bufferpickerview.lua
@@ -51,7 +51,7 @@ function BufferPickerView:draw()
   local i_x, i_y = c_x-i_w/2*i_s + self.current_buffer_x_mod, c_y-i_h/2*i_s --Image position
   local i_r = 0 --Image rotation
   g.setColor(255, 255, 255, self.current_buffer_a)
-  for i = 1, math.floor(size/2) do
+  for i = 1, math.ceil(size/2) do
     g.draw(img, i_x, i_y, i_r, i_s) --Draw image
     i_x, i_y = i_x + 10, i_y - 10
   end
@@ -65,7 +65,7 @@ function BufferPickerView:draw()
     local i_x, i_y = c_x-i_w/2*i_s + self.secondary_buffer_x_mod, c_y-i_h/2*i_s --Image position
     local i_r = 0 --Image rotation
     g.setColor(255, 255, 255, self.secondary_buffer_a)
-    for i = 1, math.floor(size/2) do
+    for i = 1, math.ceil(size/2) do
       g.draw(img, i_x, i_y, i_r, i_s) --Draw image
       i_x, i_y = i_x + 10, i_y - 10
     end

--- a/game/domain/view/bufferpickerview.lua
+++ b/game/domain/view/bufferpickerview.lua
@@ -96,9 +96,7 @@ function BufferPickerView:moveSelection(dir)
 
     --Create changing-buffer effect
     self.is_changing_buffer = true
-    if self.timers[MAIN_TIMER]["change_buffer"] then
-      MAIN_TIMER:cancel(self.timers[MAIN_TIMER]["change_buffer"])
-    end
+    self:removeTimer("change_buffer", MAIN_TIMER)
     self.current_buffer_a, self.secondary_buffer_a = 0, 255
     self.current_buffer_x_mod, self.secondary_buffer_x_mod = x_mod_value, 0
     self:addTimer("change_buffer", MAIN_TIMER, "tween",
@@ -118,9 +116,7 @@ function BufferPickerView:moveSelection(dir)
 
     --Create changing-buffer effect
     self.is_changing_buffer = true
-    if self.timers[MAIN_TIMER]["change_buffer"] then
-      MAIN_TIMER:cancel(self.timers[MAIN_TIMER]["change_buffer"])
-    end
+    self:removeTimer("change_buffer", MAIN_TIMER)
     self.current_buffer_a, self.secondary_buffer_a = 0, 255
     self.current_buffer_x_mod, self.secondary_buffer_x_mod = -x_mod_value, 0
     self:addTimer("change_buffer", MAIN_TIMER, "tween",

--- a/game/domain/view/handview.lua
+++ b/game/domain/view/handview.lua
@@ -63,13 +63,15 @@ end
 function HandView:activate()
   self.focus_index = 1
   self.action_type = 1
-  if self.timers["start"] then
-    MAIN_TIMER:cancel(self.timers["start"])
+  if self.timers[MAIN_TIMER]["start"] then
+    MAIN_TIMER:cancel(self.timers[MAIN_TIMER]["start"])
   end
-  if self.timers["end"] then
-    MAIN_TIMER:cancel(self.timers["end"])
+  if self.timers[MAIN_TIMER]["end"] then
+    MAIN_TIMER:cancel(self.timers[MAIN_TIMER]["end"])
   end
-  self.timers["start"] = MAIN_TIMER:tween(0.2, self,
+  self:addTimer("start", MAIN_TIMER, "tween",
+                                           0.2,
+                                           self,
                                            { y = self.initial_y - 200 },
                                            'out-cubic')
 end
@@ -77,14 +79,16 @@ end
 function HandView:deactivate()
   self.focus_index = -1
   self.action_type = -1
-  if self.timers["start"] then
-    MAIN_TIMER:cancel(self.timers["start"])
+  if self.timers[MAIN_TIMER]["start"] then
+    MAIN_TIMER:cancel(self.timers[MAIN_TIMER]["start"])
   end
-  if self.timers["end"] then
-    MAIN_TIMER:cancel(self.timers["end"])
+  if self.timers[MAIN_TIMER]["end"] then
+    MAIN_TIMER:cancel(self.timers[MAIN_TIMER]["end"])
   end
-  self.timers["end"] = MAIN_TIMER:tween(0.2, self,
-                                         {y = self.initial_y},
+  self:addTimer("end", MAIN_TIMER, "tween",
+                                        0.2,
+                                        self,
+                                        {y = self.initial_y},
                                          'out-cubic')
 end
 

--- a/game/domain/view/handview.lua
+++ b/game/domain/view/handview.lua
@@ -63,12 +63,8 @@ end
 function HandView:activate()
   self.focus_index = 1
   self.action_type = 1
-  if self.timers[MAIN_TIMER]["start"] then
-    MAIN_TIMER:cancel(self.timers[MAIN_TIMER]["start"])
-  end
-  if self.timers[MAIN_TIMER]["end"] then
-    MAIN_TIMER:cancel(self.timers[MAIN_TIMER]["end"])
-  end
+  self:removeTimer("start", MAIN_TIMER)
+  self:removeTimer("end", MAIN_TIMER)
   self:addTimer("start", MAIN_TIMER, "tween",
                                            0.2,
                                            self,
@@ -79,12 +75,10 @@ end
 function HandView:deactivate()
   self.focus_index = -1
   self.action_type = -1
-  if self.timers[MAIN_TIMER]["start"] then
-    MAIN_TIMER:cancel(self.timers[MAIN_TIMER]["start"])
-  end
-  if self.timers[MAIN_TIMER]["end"] then
-    MAIN_TIMER:cancel(self.timers[MAIN_TIMER]["end"])
-  end
+
+  self:removeTimer("start", MAIN_TIMER)
+  self:removeTimer("end", MAIN_TIMER)
+
   self:addTimer("end", MAIN_TIMER, "tween",
                                         0.2,
                                         self,

--- a/game/gamestates/pick_buffer.lua
+++ b/game/gamestates/pick_buffer.lua
@@ -21,16 +21,16 @@ local Filter = Class{
   __includes = {ELEMENT}
 }
 
-function Filter:init(_r, _g, _b, _a)
+function Filter:init(_r, _g, _b, _a, _target_a)
   ELEMENT.init(self)
 
   self.r = _r
   self.g = _g
   self.b = _b
-  self.a = 0
+  self.a = _a
 
   --Fade-in effect
-  ELEMENT.addTimer(self,"start", MAIN_TIMER, "tween",.2, self, {a = _a}, 'out-quad')
+  ELEMENT.addTimer(self,"start", MAIN_TIMER, "tween",.2, self, {a = _target_a}, 'out-quad')
 
 end
 
@@ -48,7 +48,14 @@ function state:enter(_, controlled_actor)
   _controlled_actor = controlled_actor
 
   --Create filter effect
-  _filter = Filter(0,0,0,180)
+  local initial_a = 0
+  if _filter then
+    _filter:removeTimer("end", MAIN_TIMER)
+    initial_a = _filter.a
+    _filter:destroy()
+  end
+
+  _filter = Filter(0,0,0, initial_a, 180)
   _filter:addElement('HUDl')
 
   --Create buffer view

--- a/game/gamestates/pick_buffer.lua
+++ b/game/gamestates/pick_buffer.lua
@@ -30,7 +30,7 @@ function Filter:init(_r, _g, _b, _a)
   self.a = 0
 
   --Fade-in effect
-  self.timers["start"] = MAIN_TIMER:tween(.2, self, {a = _a}, 'out-quad')
+  ELEMENT.addTimer(self,"start", MAIN_TIMER, "tween",.2, self, {a = _a}, 'out-quad')
 
 end
 
@@ -95,7 +95,7 @@ function state:leave()
     Signal.clear("confirm")
     Signal.clear("cancel")
     _buffer_picker_view:destroy()
-    _filter.timers["end"] = MAIN_TIMER:tween(.2, _filter, {a = 0}, 'in-linear', function() _filter:destroy() end)
+    _filter:addTimer("end", MAIN_TIMER, "tween", .2, _filter, {a = 0}, 'in-linear', function() _filter:destroy() end)
 
     CONTROL.setMap(_previous_control_map)
 end


### PR DESCRIPTION
Fixed fade-in/fade-out bug when toggling quickly buffer_picker state, and now drawing more accurately buffer cards (if you have 1 card should still draw a card in buffer).
Drawing backbuffer number next to buffer size (inside [ ]'s )

Refactor usage of timers to new STEAMING element functions. So after merging with this PR, you should 'make clean' and 'make update' once