### PR TITLE
Add source base dir to cpath for external compiled libs

### DIFF
--- a/game/libs/init.lua
+++ b/game/libs/init.lua
@@ -1,4 +1,5 @@
 
 local fs = love.filesystem
 fs.setRequirePath("libs/?/init.lua;libs/?.lua;"..fs.getRequirePath())
+package.cpath = fs.getSourceBaseDirectory().."/?.so;" .. package.cpath
 


### PR DESCRIPTION
This makes it possible to run the game from any folder in your system. Still unix-only as it supposes it's a `*.so` file