### PR TITLE
Slight action menu improvement

### DIFF
--- a/game/gamestates/action_menu.lua
+++ b/game/gamestates/action_menu.lua
@@ -75,6 +75,10 @@ end
 
 function state:enter(_, route)
 
+  local player = route.getControlledActor()
+  local action = 'drawhand'
+  if player:getHandSize() > 0 then action = 'playcard' end
+  _menu_view:setCardAction(action)
   _menu_view:open(_last_focus)
   _registerSignals()
 

--- a/game/setup.lua
+++ b/game/setup.lua
@@ -48,6 +48,8 @@ function setup.config()
     BGM = { --Table containing all the background music tracks
     }
 
+
+    love.keyboard.setKeyRepeat(true)
     --SHADERS--
         --
 

--- a/game/view/actionmenu.lua
+++ b/game/view/actionmenu.lua
@@ -8,7 +8,7 @@ local _W, _H
 local _ANGLE = math.pi/4
 local _RADIUS = 196
 local _ACTIONS = {
-  'interact', 'primary', 'widget', 'playcard', 'drawhand', 'openpack', 'wait',
+  'interact', 'primary', 'widget', 'drawhand', 'openpack', 'wait',
   interact = "Interact",
   primary = "Primary Arte",
   widget = "Use Widget",
@@ -22,6 +22,7 @@ local _TWEEN = {
   TEXT = "__TEXT__",
   SWITCH = "__SWITCH__",
 }
+local _DRAWHAND = 4
 
 -- LOCAL FUNCTION DECLARATIONS -------------------------------------------------
 
@@ -42,6 +43,10 @@ function ActionMenu:init()
   self.text = 0
   _W, _H = love.graphics.getDimensions()
 
+end
+
+function ActionMenu:setCardAction(action_name)
+  _ACTIONS[_DRAWHAND] = action_name
 end
 
 function ActionMenu:showLabel()


### PR DESCRIPTION
This PR makes it so that when you have cards on your hand you can't try to buy more, and instead the menu points to the 'play card' option. When you don't have cards on your hand, the action menu shows the option of drawing cards from buffer, but doesn't show the 'play card' option

also if you hold and input, the game keeps pressing it rythmically now