### PR TITLE
Move widgets to body

### DIFF
--- a/game/domain/actor.lua
+++ b/game/domain/actor.lua
@@ -60,8 +60,8 @@ function Actor:loadState(state)
     local card = DEFS.DONE
     if card_state ~= card then
       card = Card(state.buffer.specname)
-      card:setOwner(self)
       card:loadState(card_state)
+      card:setOwner(self)
     end
     self.buffer[i] = card
   end

--- a/game/domain/actor.lua
+++ b/game/domain/actor.lua
@@ -6,7 +6,6 @@ local ACTION      = require 'domain.action'
 local ABILITY     = require 'domain.ability'
 local RANDOM      = require 'common.random'
 local DEFS        = require 'domain.definitions'
-local PLACEMENTS  = require 'domain.definitions.placements'
 local PACK        = require 'domain.pack'
 
 local Actor = Class{
@@ -52,7 +51,9 @@ function Actor:loadState(state)
   for _,card_state in ipairs(state.hand) do
     local card = Card(card_state.specname)
     card:loadState(card_state)
-    card:setOwner(self)
+    if not card.owner_id then
+      card:setOwner(self)
+    end
     table.insert(self.hand, card)
   end
   self.buffer = {}
@@ -61,7 +62,9 @@ function Actor:loadState(state)
     if card_state ~= card then
       card = Card(state.buffer.specname)
       card:loadState(card_state)
-      card:setOwner(self)
+      if not card.owner_id then
+        card:setOwner(self)
+      end
     end
     self.buffer[i] = card
   end

--- a/game/domain/body.lua
+++ b/game/domain/body.lua
@@ -1,16 +1,24 @@
 
-local RANDOM = require 'common.random'
+local RANDOM      = require 'common.random'
+local PLACEMENTS  = require 'domain.definitions.placements'
 local GameElement = require 'domain.gameelement'
 
 local Body = Class{
   __includes = { GameElement }
 }
 
+--[[ Setup methods ]]--
+
 function Body:init(specname)
 
   GameElement.init(self, 'body', specname)
 
   self.damage = 0
+  self.widgets = {}
+  self.equipped = {}
+  for placement in ipairs(PLACEMENTS) do
+    self.equipped[placement] = false
+  end
   self.upgrades = {
     DEF = 0,
     HP = 0,
@@ -24,6 +32,15 @@ function Body:loadState(state)
   self.upgrades = state.upgrades
   self.sector_id = state.sector_id
   self:setId(state.id)
+  self.equipped = state.equipped
+  self.widgets = {}
+  for index, card_state in pairs(state.widgets) do
+    if card_state then
+      local card = Card(card_state.specname)
+      card:loadState(card_state)
+      self.widgets[index] = card
+    end
+  end
 end
 
 function Body:saveState()
@@ -33,8 +50,18 @@ function Body:saveState()
   state.upgrades = self.upgrades
   state.sector_id = self.sector_id
   state.id = self.id
+  state.equipped = self.equipped
+  state.widgets = {}
+  for index, card in pairs(self.widgets) do
+    if card then
+      local card_state = card:saveState()
+      state.widgets[index] = card_state
+    end
+  end
   return state
 end
+
+--[[ Sector-related methods ]]--
 
 function Body:setSector(sector_id)
   self.sector_id = sector_id
@@ -47,6 +74,14 @@ end
 function Body:getPos()
   return self:getSector():getBodyPos(self)
 end
+
+--[[ Appearance methods ]]--
+
+function Body:getAppearance()
+  return self:getSpec('appearance')
+end
+
+--[[ HP methods ]]--
 
 function Body:getHP()
   return self:getMaxHP() - self.damage
@@ -72,6 +107,8 @@ function Body:setHP(hp)
   self.damage = math.max(0, math.min(self:getMaxHP() - hp, self:getMaxHP()))
 end
 
+--[[ DEF methods ]]--
+
 function Body:getDEF()
   return self:getSpec('def') + self.upgrades.DEF
 end
@@ -83,6 +120,82 @@ end
 function Body:upgradeDEF(val)
   self.upgrades.DEF = self.upgrades.DEF + val
 end
+
+--[[ Widget methods ]]--
+
+function Body:isEquipped(place)
+  return place and self.equipped[place]
+end
+
+function Body:equip(place, card)
+  if not place then return end
+  -- check if placement is being used
+  -- if it is, then remove card from that slot
+  if self:isEquipped(place) then
+    local index
+    for i,widget in ipairs(self.widgets) do
+      if widget == self.equipped[place] then
+        index = i
+        break
+      end
+    end
+    local card = self:removeWidget(index)
+    local owner = card:getOwner()
+    if owner and not card:isOneTimeOnly() then
+      owner:addCardToBackbuffer(card)
+    end
+  end
+  -- equip new thing on index
+  self.equipped[place] = card
+end
+
+function Body:unequip(place)
+  if not place then return end
+  self.equipped[place] = false
+end
+
+function Body:hasWidgetAt(index)
+  return not not self.widgets[index]
+end
+
+function Body:removeWidget(index)
+  local card = self.widgets[index]
+  local placement = card:getWidgetPlacement()
+  self:unequip(placement)
+  table.remove(self.widgets, index)
+  return card
+end
+
+function Body:placeWidget(card)
+  local placement = card:getWidgetPlacement()
+  table.insert(self.widgets, card)
+  self:equip(placement, card)
+end
+
+function Body:getWidget(index)
+  return index and self.widgets[index]
+end
+
+function Body:getWidgetNameAt(index)
+  local card = self.widgets[index]
+  if card then return card:getName() end
+end
+
+function Body:spendWidget(index)
+  local card = self.widgets[index]
+  if card then
+    card:addUsages()
+    if card:isSpent() then
+      return self:removeWidget(index)
+    end
+  end
+end
+
+function Body:eachWidget()
+  return ipairs(self.widgets)
+end
+
+--[[ Combat methods ]]--
 
 function Body:takeDamage(amount)
   local defroll = RANDOM.rollDice(self:getDEF(), self:getBaseDEF())
@@ -96,8 +209,5 @@ function Body:heal(amount)
   self.damage = math.max(0, self.damage - amount)
 end
 
-function Body:getAppearance()
-  return self:getSpec('appearance')
-end
-
 return Body
+

--- a/game/domain/card.lua
+++ b/game/domain/card.lua
@@ -10,18 +10,21 @@ function Card:init(specname)
 
   GameElement.init(self, 'card', specname)
   self.usages = 0
+  self.owner_id = nil
 
 end
 
 function Card:loadState(state)
   self.specname = state.specname
   self.usages = state.usages
+  self.owner_id = state.owner_id
 end
 
 function Card:saveState()
   local state = {}
   state.specname = self.specname
   state.usages = self.usages
+  state.owner_id = self.owner_id
   return state
 end
 
@@ -39,6 +42,14 @@ end
 
 function Card:getRelatedAttr()
   return self:getSpec('attr')
+end
+
+function Card:getOwner()
+  return Util.find(self:getSpec('owner_id'))
+end
+
+function Card:setOwner(owner)
+  self.owner_id = owner.id
 end
 
 function Card:isOneTimeOnly()

--- a/game/domain/card.lua
+++ b/game/domain/card.lua
@@ -45,7 +45,7 @@ function Card:getRelatedAttr()
 end
 
 function Card:getOwner()
-  return Util.find(self:getSpec('owner_id'))
+  return Util.findId(self.owner_id)
 end
 
 function Card:setOwner(owner)

--- a/game/domain/definitions/init.lua
+++ b/game/domain/definitions/init.lua
@@ -4,13 +4,14 @@ local DEFS = {}
 -- + [x] Xform BACKBUFFER CONSUMPTION into MANEUVER
 -- + [x] Xform all basic actions into MANEUVERS
 -- + [x] Smarter slots + endless widgets
--- + [ ] Move widgets to body
+-- + [x] Move widgets to body
 -- + [ ] Widget buffs
 -- + [ ] Stashed widgets
 
 -- + [x] Write action names down as definitions
 -- + [x] Adapt widget selector view to new reality
 -- + [x] Remove Actor.actions since it only needs Action.signature now
+-- + [ ] Add placement spec to bodies
 -- + [ ] Join Actor:getCard() and Actor:getHandCard()
 
 DEFS.DONE = "__DONE_VALUE__"

--- a/game/domain/maneuver/activate_widget.lua
+++ b/game/domain/maneuver/activate_widget.lua
@@ -8,21 +8,22 @@ ACTIVATE.param_specs = {
 }
 
 function ACTIVATE.activatedAbility(actor, sector, params)
-  return actor:getWidget(params.widget_slot):getWidgetAbility()
+  return actor:getBody():getWidget(params.widget_slot):getWidgetAbility()
 end
 
 function ACTIVATE.validate(actor, sector, params)
   if not params.widget_slot then return false end
-  local widget = actor:getWidget(params.widget_slot)
+  local widget = actor:getBody():getWidget(params.widget_slot)
   if not widget then return false end
   local ability = widget:getWidgetAbility()
   return ability and ABILITY.checkParams(ability, actor, sector, params)
 end
 
 function ACTIVATE.perform(actor, sector, params)
-  local widget = actor:getWidget(params.widget_slot)
+  local body = actor:getBody()
+  local widget = body:getWidget(params.widget_slot)
   local ability = widget:getWidgetAbility()
-  actor:spendWidget(params.widget_slot)
+  body:spendWidget(params.widget_slot)
   actor:spendTime(widget:getWidgetActivationCost())
   actor:rewardPP(widget:getPPReward())
   ABILITY.execute(ability, actor, sector, params)

--- a/game/domain/maneuver/play_card.lua
+++ b/game/domain/maneuver/play_card.lua
@@ -37,7 +37,7 @@ function PLAYCARD.perform(actor, sector, params)
     actor:rewardPP(card:getPPReward())
     ABILITY.execute(card:getArtAbility(), actor, sector, params)
   elseif card:isWidget() then
-    actor:placeWidget(card)
+    actor:getBody():placeWidget(card)
   elseif card:isUpgrade() then
     actor:modifyExpBy(-card:getUpgradeCost())
     local upgrades = card:getUpgradesList()

--- a/game/domain/maneuver/receive_pack.lua
+++ b/game/domain/maneuver/receive_pack.lua
@@ -19,6 +19,7 @@ function RECEIVEPACK.perform(actor, sector, params)
     actor:consumeCard(card)
   end
   for _,card in ipairs(params.pack) do
+    card:setOwner(actor)
     actor:addCardToBackbuffer(card)
   end
 end

--- a/game/domain/params/choose_widget_slot.lua
+++ b/game/domain/params/choose_widget_slot.lua
@@ -8,7 +8,7 @@ PARAM.schema = {
 PARAM.type = 'widget_slot'
 
 function PARAM.isValid(sector, actor, parameter, value)
-  if not actor:hasWidgetAt(value) then
+  if not actor:getBody():hasWidgetAt(value) then
     return false
   end
   return true

--- a/game/infra/routebuilder.lua
+++ b/game/infra/routebuilder.lua
@@ -41,19 +41,6 @@ local function _generatePlayerActorData(idgenerator, body_id, background)
     cooldown = 10,
     exp = 0,
     playpoints = 10,
-    equipped = {
-      weapon = false,
-      offhand = false,
-      suit = false,
-      tool = false,
-      accessory = false,
-    },
-    widgets = {
-      WIDGET_A = false,
-      WIDGET_B = false,
-      WIDGET_C = false,
-      WIDGET_D = false,
-    },
     upgrades = {ATH=0,ARC=0,MEC=0,SPD=0},
     buffer = _simpleBuffer(),
     hand_limit = 5,
@@ -69,6 +56,14 @@ local function _generatePlayerBodyData(idgenerator, species)
     upgrades = {DEF=0,HP=0},
     i = 3,
     j = 5,
+    equipped = {
+      weapon = false,
+      offhand = false,
+      suit = false,
+      tool = false,
+      accessory = false,
+    },
+    widgets = {},
   }
 end
 

--- a/game/view/pickwidget.lua
+++ b/game/view/pickwidget.lua
@@ -49,7 +49,7 @@ function PickWidgetView:draw()
 
   g.translate(_width/8, _height/2-2*(_BLOCK_HEIGHT+_MARGIN))
   -- draw stuff
-  for index, widget in self.target:eachWidget() do
+  for index, widget in self.target:getBody():eachWidget() do
     local name, pd
     name = widget:getName()
     local selected = self.selection == index


### PR DESCRIPTION
Bodies now hold widgets. Actors no longer carry widgets.

Close #405 

Notes:
1. Cards now have an "owner" actor
2. When widgets are discarded, they return to their "owner"
3. Loaded cards and cards received from packs are automatically assigned their owner
