### PR TITLE
Make views be destroyed after closing

### DIFF
--- a/game/gamestates/action_menu.lua
+++ b/game/gamestates/action_menu.lua
@@ -69,8 +69,6 @@ function state:init()
       Signal.emit(unpack(signal_pack))
     end
   end
-  _menu_view = ActionMenuView()
-  _menu_view:addElement('HUD')
 end
 
 function state:enter(_, route)
@@ -78,6 +76,8 @@ function state:enter(_, route)
   local player = route.getControlledActor()
   local action = 'drawhand'
   if player:getHandSize() > 0 then action = 'playcard' end
+  _menu_view = ActionMenuView()
+  _menu_view:addElement('HUD')
   _menu_view:setCardAction(action)
   _menu_view:open(_last_focus)
   _registerSignals()
@@ -87,7 +87,6 @@ end
 function state:leave()
 
   _unregisterSignals()
-  Util.destroyAll()
 
 end
 
@@ -96,8 +95,6 @@ function state:update(dt)
   if not DEBUG then
     MAIN_TIMER:update(dt)
   end
-
-  Util.destroyAll()
 
 end
 

--- a/game/gamestates/manage_buffer.lua
+++ b/game/gamestates/manage_buffer.lua
@@ -24,13 +24,13 @@ function state:init()
       if not _view:isLocked() then _leave = true end
     end,
   }
-  _view = ManageBufferView("UP")
-  _view:addElement("HUD")
 end
 
 function state:enter(from, actor)
   if actor:getBackBufferSize() > 0 then
     _leave = false
+    _view = ManageBufferView("UP")
+    _view:addElement("HUD")
     _view:open(actor:copyBackBuffer())
     CONTROLS.setMap(_mapping)
   else
@@ -40,6 +40,7 @@ end
 
 function state:leave()
   _view:close()
+  _view = nil
 end
 
 function state:update(dt)

--- a/game/gamestates/open_pack.lua
+++ b/game/gamestates/open_pack.lua
@@ -26,8 +26,6 @@ function state:init()
       end
     end,
   }
-  _view = PackView("UP")
-  _view:addElement("HUD")
 end
 
 function state:enter(from, actor)
@@ -41,12 +39,15 @@ function state:enter(from, actor)
   while actor:hasOpenPack() do actor:removePackCard(1) end
 
   CONTROLS.setMap(_mapping)
+  _view = PackView("UP")
+  _view:addElement("HUD")
   _view:open(_pack)
 end
 
 function state:leave()
   _leave = false
   _view:close()
+  _view = nil
 end
 
 function state:update(dt)

--- a/game/gamestates/play.lua
+++ b/game/gamestates/play.lua
@@ -109,6 +109,7 @@ end
 function state:update(dt)
 
   if not DEBUG then
+    MAIN_TIMER:update(dt)
     if _next_action then
       _playTurns(unpack(_next_action))
     end

--- a/game/gamestates/start_menu.lua
+++ b/game/gamestates/start_menu.lua
@@ -21,7 +21,6 @@ end
 --STATE FUNCTIONS--
 
 function state:init()
-  _menu_view = StartMenuView()
   _mapping = {
     PRESS_CONFIRM  = MENU.confirm,
     PRESS_SPECIAL  = MENU.cancel,
@@ -33,13 +32,16 @@ function state:init()
 end
 
 function state:enter()
-  _menu_view:addElement("HUD", nil, "menu_view")
+  _menu_view = StartMenuView()
+  _menu_view:addElement("GUI", nil, "menu_view")
+  _menu_view:open()
   _menu_context = "START_MENU"
   CONTROLS.setMap(_mapping)
 end
 
 function state:leave()
   _menu_view:destroy()
+  _menu_view = nil
 end
 
 function state:resume(from, player_info)
@@ -59,6 +61,7 @@ function state:resume(from, player_info)
 end
 
 function state:update(dt)
+  MAIN_TIMER:update(dt)
   _menu_view.invisible = false
   if MENU.begin(_menu_context) then
     if _menu_context == "START_MENU" then

--- a/game/view/actionmenu.lua
+++ b/game/view/actionmenu.lua
@@ -99,7 +99,6 @@ end
 function ActionMenu:open(last_focus)
   if _enter_tween.tween or _enter_tween.currentview then
     MAIN_TIMER:cancel(_enter_tween.tween)
-    _enter_tween.enter = 0
     _enter_tween.currentview.invisible = true
   end
   _enter_tween.currentview = self

--- a/game/view/actionmenu.lua
+++ b/game/view/actionmenu.lua
@@ -68,7 +68,8 @@ end
 function ActionMenu:hideLabel()
   self:removeTimer(_TWEEN.TEXT, MAIN_TIMER)
   self:addTimer(_TWEEN.TEXT, MAIN_TIMER, "tween",
-    0.01 * self.text, self, { text = 0 }, 'linear')
+    0.05 * self.text, self, { text = 0 }, 'linear',
+    function () self:destroy() end)
 end
 
 function ActionMenu:moveFocus(dir)
@@ -100,15 +101,15 @@ function ActionMenu:open(last_focus)
   self.current = last_focus or self.current
   self:removeTimer(_TWEEN.OPEN_CLOSE, MAIN_TIMER)
   self:addTimer(_TWEEN.OPEN_CLOSE, MAIN_TIMER, "tween",
-                0.2, self, { enter = 1 }, 'out-circ')
+                0.3, self, { enter = 1 }, 'out-circ')
   self:showLabel()
 end
 
 function ActionMenu:close()
   self:removeTimer(_TWEEN.OPEN_CLOSE, MAIN_TIMER)
   self:addTimer(_TWEEN.OPEN_CLOSE, MAIN_TIMER, "tween",
-                0.2, self, { enter = 0 }, 'out-circ',
-                function() self.invisible = true end)
+                0.3, self, { enter = 0 }, 'out-circ',
+                function()  end)
   self:hideLabel()
 end
 

--- a/game/view/actionmenu.lua
+++ b/game/view/actionmenu.lua
@@ -29,6 +29,7 @@ local _DRAWHAND = 4
 
 -- LOCAL VARIABLES -------------------------------------------------------------
 
+local _enter_tween = { enter = 0, tween = false, currentview = false }
 local _font
 
 -- LOCAL FUNCTION DECLARATIONS -------------------------------------------------
@@ -45,7 +46,6 @@ function ActionMenu:init()
 
   ELEMENT.init(self)
   self.current = 1
-  self.enter = 0
   self.switch = 0
   self.text = 0
   _W, _H = love.graphics.getDimensions()
@@ -62,14 +62,14 @@ function ActionMenu:showLabel()
   self.text = 0
   self:removeTimer(_TWEEN.TEXT, MAIN_TIMER)
   self:addTimer(_TWEEN.TEXT, MAIN_TIMER, "tween",
-    0.05 * len, self, { text = len+1 }, 'linear')
+                0.05 * len, self, { text = len+1 }, 'linear')
 end
 
 function ActionMenu:hideLabel()
   self:removeTimer(_TWEEN.TEXT, MAIN_TIMER)
   self:addTimer(_TWEEN.TEXT, MAIN_TIMER, "tween",
-    0.05 * self.text, self, { text = 0 }, 'linear',
-    function () self:destroy() end)
+                0.05 * self.text, self, { text = 0 }, 'linear',
+                function () self:destroy() end)
 end
 
 function ActionMenu:moveFocus(dir)
@@ -97,23 +97,36 @@ function ActionMenu:getSelected()
 end
 
 function ActionMenu:open(last_focus)
+  if _enter_tween.tween or _enter_tween.currentview then
+    MAIN_TIMER:cancel(_enter_tween.tween)
+    _enter_tween.enter = 0
+    _enter_tween.currentview.invisible = true
+  end
+  _enter_tween.currentview = self
+  _enter_tween.tween = MAIN_TIMER:tween(0.3, _enter_tween, { enter = 1 },
+                                        'out-circ', function()
+                                          _enter_tween.tween = false
+                                        end
+  )
   self.current = last_focus or self.current
-  self:removeTimer(_TWEEN.OPEN_CLOSE, MAIN_TIMER)
-  self:addTimer(_TWEEN.OPEN_CLOSE, MAIN_TIMER, "tween",
-                0.3, self, { enter = 1 }, 'out-circ')
   self:showLabel()
 end
 
 function ActionMenu:close()
-  self:removeTimer(_TWEEN.OPEN_CLOSE, MAIN_TIMER)
-  self:addTimer(_TWEEN.OPEN_CLOSE, MAIN_TIMER, "tween",
-                0.3, self, { enter = 0 }, 'out-circ')
+  if _enter_tween.tween then MAIN_TIMER:cancel(_enter_tween.tween) end
+  _enter_tween.tween = MAIN_TIMER:tween(0.3, _enter_tween, { enter = 0 },
+                                        'out-circ', function()
+                                          _enter_tween.tween = false
+                                          _enter_tween.currentview = false
+                                          self.invisible = true
+                                        end
+  )
   self:hideLabel()
 end
 
 function ActionMenu:draw()
   local g = love.graphics
-  local enter = self.enter
+  local enter = _enter_tween.enter
   local switch = self.switch
   local cos, sin, pi = math.cos, math.sin, math.pi
   local min, max, abs = math.min, math.max, math.abs

--- a/game/view/actionmenu.lua
+++ b/game/view/actionmenu.lua
@@ -107,8 +107,7 @@ end
 function ActionMenu:close()
   self:removeTimer(_TWEEN.OPEN_CLOSE, MAIN_TIMER)
   self:addTimer(_TWEEN.OPEN_CLOSE, MAIN_TIMER, "tween",
-                0.3, self, { enter = 0 }, 'out-circ',
-                function()  end)
+                0.3, self, { enter = 0 }, 'out-circ')
   self:hideLabel()
 end
 

--- a/game/view/actionmenu.lua
+++ b/game/view/actionmenu.lua
@@ -97,7 +97,6 @@ function ActionMenu:getSelected()
 end
 
 function ActionMenu:open(last_focus)
-  self.invisible = false
   self.current = last_focus or self.current
   self:removeTimer(_TWEEN.OPEN_CLOSE, MAIN_TIMER)
   self:addTimer(_TWEEN.OPEN_CLOSE, MAIN_TIMER, "tween",

--- a/game/view/cardlist.lua
+++ b/game/view/cardlist.lua
@@ -72,7 +72,6 @@ function View:isLocked()
 end
 
 function View:open(card_list)
-  self.invisible = false
   self.card_list = card_list
   self.consume_log = {}
   self.holdbar:unlock()
@@ -90,8 +89,8 @@ function View:close()
   self:addTimer(_ENTER_TIMER, MAIN_TIMER, "tween",
                 _ENTER_SPEED, self, { enter=0, text=0 }, "out-quad",
                 function ()
-                  self.invisible = true
                   self.card_list = _EMPTY
+                  self:destroy()
                 end)
 end
 

--- a/game/view/startmenu.lua
+++ b/game/view/startmenu.lua
@@ -74,11 +74,22 @@ function StartMenuView:init()
   self.title = "backdoor"
   self.selection = 1
   self.scrolltop = 1
+  self.enter = 0
 
   _initFontValues()
 
 end
 
+
+function StartMenuView:open()
+  self:addTimer("startmenu_enter", MAIN_TIMER, "tween", 1,
+                self, { enter = 1 }, "in-out-quad"
+  )
+end
+
+function StartMenuView:close()
+  self.enter = 0
+end
 
 function StartMenuView:setItem(item_text)
   self.queue.push(item_text)
@@ -109,6 +120,12 @@ function StartMenuView:draw()
   _renderOptions(q, self.selection, self.scrolltop)
 
   g.pop()
+
+  if self.enter < 1 then
+    g.setColor(0, 0, 0, 0xff*(1-self.enter))
+    g.rectangle("fill", 0, 0, g.getDimensions())
+  end
+
 end
 
 


### PR DESCRIPTION
Fix #422 
Also adds a fade in to start menu so it doesn't startle the player. We should add one to sectorview too, but that's slightly more complicated and goes beyond this issue.