### PR TITLE
Add ability hints and info descriptions

### DIFF
--- a/game/database/schema/card.lua
+++ b/game/database/schema/card.lua
@@ -10,12 +10,15 @@ return {
   { id = 'pp', name = "PlayPoint Reward", type = 'integer' },
   { id = 'attr', name = "Type (attr)", type = 'enum',
     options = DEFS.PRIMARY_ATTRIBUTES },
+  { id = 'type-description', type = 'description',
+    info = "Cards can be either Arts, Upgrades, or Widgets" },
   {
     id = 'art', name = "Art",
     type = 'section',
     schema = {
       { id = 'cost', name = "Cost", type = 'integer', range = {0} },
-      { id = 'art_ability', name = "Art Ability", type = 'ability' },
+      { id = 'art_ability', name = "Art Ability", type = 'ability',
+        hint = "Happens when card is played from hand" },
     }
   },
   {
@@ -67,7 +70,8 @@ return {
         schema = {
           { id = 'cost', name = "Time Cost", type = 'integer',
             range = {0} },
-          { id = 'ability', name = "Ability", type = 'ability' }
+          { id = 'ability', name = "Ability", type = 'ability',
+            hint = "Happens when widget is activated" }
         }
       },
       {
@@ -75,7 +79,8 @@ return {
         schema = {
           { id = 'trigger', name = "Trigger", type = 'enum',
             options = DEFS.TRIGGERS },
-          { id = 'ability', name = "Ability", type = 'ability' }
+          { id = 'ability', name = "Ability", type = 'ability',
+            hint = "Happens when trigger is detected" }
         }
       },
     },

--- a/game/debug/view/input/ability.lua
+++ b/game/debug/view/input/ability.lua
@@ -92,6 +92,9 @@ function inputs.ability(spec, key)
     IMGUI.Text(("%s"):format(key.name))
     if _active then
       IMGUI.Indent(20)
+      if key.hint then
+        IMGUI.Text(key.hint)
+      end
       for _,cmdtype in ipairs(_CMDTYPES) do
         selected = _commandList(self, ability, cmdtype, selected, delete)
       end

--- a/game/debug/view/input/common.lua
+++ b/game/debug/view/input/common.lua
@@ -6,7 +6,9 @@ local inputs = {}
 local function _makeCommon(default, call)
   return function(spec, key)
     return function(self)
-      IMGUI.Text(key.name)
+      if key.name then
+        IMGUI.Text(key.name)
+      end
       local value = spec[key.id] or default
       IMGUI.PushID(key.id)
       local changed, newvalue = call(value, key)
@@ -53,6 +55,14 @@ inputs.text = _makeCommon(
     local changed, newvalue = IMGUI.InputTextMultiline("", value, 256)
     IMGUI.PopItemWidth()
     return changed, newvalue
+  end
+)
+
+inputs.description = _makeCommon(
+  "",
+  function(value, key)
+    IMGUI.Text(key.info)
+    return false
   end
 )
 


### PR DESCRIPTION
You can now add simple descriptions to schemas.

Try editing a card and pay attention to what appears written.