### PR TITLE
Remove redundant sector parameters

### DIFF
--- a/game/domain/ability.lua
+++ b/game/domain/ability.lua
@@ -28,11 +28,11 @@ function ABILITY.param(param_name)
   return PAR[param_name]
 end
 
-function ABILITY.validate(param_name, sector, actor, param, value)
-  return PAR[param_name].isValid(sector, actor, param, value)
+function ABILITY.validate(param_name, actor, param, value)
+  return PAR[param_name].isValid(actor, param, value)
 end
 
-function ABILITY.checkParams(ability, actor, sector, params)
+function ABILITY.checkParams(ability, actor, params)
   for i,parameter in ipairs(ability.params) do
     local argvalues = {}
     local parname, valname = parameter.typename, parameter.output
@@ -40,7 +40,7 @@ function ABILITY.checkParams(ability, actor, sector, params)
       argvalues[arg.id] = unref(params, {}, parameter[arg.id])
     end
     local paramspec = PAR[parameter.typename]
-    if not paramspec.isValid(sector, actor, argvalues,
+    if not paramspec.isValid(actor, argvalues,
                              params[parameter.output]) then
       return false
     end
@@ -48,7 +48,7 @@ function ABILITY.checkParams(ability, actor, sector, params)
   return true
 end
 
-function ABILITY.execute(ability, actor, sector, params)
+function ABILITY.execute(ability, actor, params)
   local values = {}
   for i,operation in ipairs(ability.operators) do
     local argvalues = {}
@@ -56,7 +56,7 @@ function ABILITY.execute(ability, actor, sector, params)
     for _,arg in DB.schemaFor('operators/'..opname) do
       argvalues[arg.id] = unref(params, values, operation[arg.id])
     end
-    values[valname] = OP[opname].process(actor, sector, argvalues)
+    values[valname] = OP[opname].process(actor, argvalues)
   end
   for i,effect_spec in ipairs(ability.effects) do
     local argvalues = {}
@@ -64,7 +64,7 @@ function ABILITY.execute(ability, actor, sector, params)
     for _,arg in DB.schemaFor('effects/'..fx_name) do
       argvalues[arg.id] = unref(params, values, effect_spec[arg.id])
     end
-    FX[fx_name].process(actor, sector, argvalues)
+    FX[fx_name].process(actor, argvalues)
   end
 end
 

--- a/game/domain/action.lua
+++ b/game/domain/action.lua
@@ -9,14 +9,14 @@ function ACTION.exists(action_name)
   return not not MANEUVERS[action_name]
 end
 
-function ACTION.pendingParam(action_name, actor, sector, params)
+function ACTION.pendingParam(action_name, actor, params)
   local maneuver = MANEUVERS[action_name]
   for _,param_spec in ipairs(maneuver.param_specs) do
     if not params[param_spec.output] then
       return param_spec
     end
   end
-  local activated_ability = maneuver.activatedAbility(actor, sector, params)
+  local activated_ability = maneuver.activatedAbility(actor, params)
   if activated_ability then
     for _,param_spec in ABILITY.paramsOf(activated_ability) do
       if not params[param_spec.output] then
@@ -30,12 +30,12 @@ function ACTION.ability(action_name)
   return (DB.loadSpec('action', action_name) or {}).ability
 end
 
-function ACTION.execute(action_slot, actor, sector, params)
+function ACTION.execute(action_slot, actor, params)
   local maneuver = MANEUVERS[action_slot]
-  if not maneuver or not maneuver.validate(actor, sector, params) then
+  if not maneuver or not maneuver.validate(actor, params) then
     return false
   end
-  maneuver.perform(actor, sector, params)
+  maneuver.perform(actor, params)
   return true
 end
 

--- a/game/domain/actor.lua
+++ b/game/domain/actor.lua
@@ -364,11 +364,12 @@ function Actor:playCard(card_index)
 end
 
 function Actor:turn()
-  self:getBody():triggerWidgets(DEFS.TRIGGERS.ON_TURN, sector)
+  self:getBody():triggerWidgets(DEFS.TRIGGERS.ON_TURN)
 end
 
-function Actor:makeAction(sector)
+function Actor:makeAction()
   local success = false
+  local sector = self:getBody():getSector()
   repeat
     local action_slot, params = self:behavior(sector)
     if ACTION.exists(action_slot) then

--- a/game/domain/actor.lua
+++ b/game/domain/actor.lua
@@ -369,11 +369,10 @@ end
 
 function Actor:makeAction()
   local success = false
-  local sector = self:getBody():getSector()
   repeat
-    local action_slot, params = self:behavior(sector)
+    local action_slot, params = self:behavior()
     if ACTION.exists(action_slot) then
-      success = ACTION.execute(action_slot, self, sector, params)
+      success = ACTION.execute(action_slot, self, params)
     end
   until success
   return true

--- a/game/domain/behaviors/aggro.lua
+++ b/game/domain/behaviors/aggro.lua
@@ -83,8 +83,9 @@ local function _findPath(start, goal, sector)
   return false
 end
 
-return function (actor, sector)
+return function (actor)
   local target, dist
+  local sector = actor:getBody():getSector()
   local i, j = actor:getPos()
 
   -- create list of opponents

--- a/game/domain/behaviors/player.lua
+++ b/game/domain/behaviors/player.lua
@@ -1,5 +1,5 @@
 
-return function (actor, sector)
+return function (actor)
   -- This returns the action chosen by the user. See gamestate.play and
   -- gamestate.user_turn
   return select(2,coroutine.yield("userTurn", actor))

--- a/game/domain/body.lua
+++ b/game/domain/body.lua
@@ -294,7 +294,7 @@ function Body:triggerOneWidget(index, trigger, params)
   if widget:getWidgetTrigger() == trigger then
     local condition = widget:getWidgetTriggerCondition()
     if not condition
-        or ABILITY.checkParams(condition, owner, self.getSector(), params) then
+        or ABILITY.checkParams(condition, owner, params) then
       self:spendWidget(index)
     end
   end
@@ -302,8 +302,8 @@ function Body:triggerOneWidget(index, trigger, params)
   if triggered_ability.trigger == trigger then
     local ability = triggered_ability.ability
     if ability then
-      if ABILITY.checkParams(ability, owner, self:getSector(), params) then
-        ABILITY.execute(ability, owner, self:getSector(), params)
+      if ABILITY.checkParams(ability, owner, params) then
+        ABILITY.execute(ability, owner, params)
       end
     end
   end

--- a/game/domain/effects/add_card_to_backbuffer.lua
+++ b/game/domain/effects/add_card_to_backbuffer.lua
@@ -7,7 +7,7 @@ FX.schema = {
   { id = 'card', name = "Card", type = 'value', match = 'card' }, 
 }
 
-function FX.process (actor, sector, params)
+function FX.process (actor, params)
   actor:addCardToBackbuffer(params['card'])
 end
 

--- a/game/domain/effects/change_sector.lua
+++ b/game/domain/effects/change_sector.lua
@@ -7,7 +7,7 @@ FX.schema = {
   { id = 'target_pos', name = "Target Position", type = 'value', match = 'pos' }
 }
 
-function FX.process(actor, sector, params)
+function FX.process(actor, params)
   local target_sector = Util.findId(params.target_sector)
   target_sector:putActor(actor, unpack(params.target_pos))
 end

--- a/game/domain/effects/consume_card.lua
+++ b/game/domain/effects/consume_card.lua
@@ -5,7 +5,7 @@ FX.schema = {
   { id = 'card', name = "Consumed card", type = 'value', match = 'card' }, 
 }
 
-function FX.process (actor, sector, params)
+function FX.process (actor, params)
   actor:consumeCard(params['card'])
 end
 

--- a/game/domain/effects/deal_damage.lua
+++ b/game/domain/effects/deal_damage.lua
@@ -7,8 +7,8 @@ FX.schema = {
     range = {0} },
 }
 
-function FX.process (actor, sector, params)
-  params.target:takeDamageFrom(params.amount or 2, actor, sector)
+function FX.process (actor, params)
+  params.target:takeDamageFrom(params.amount or 2, actor)
 end
 
 return FX

--- a/game/domain/effects/dmg_formula.lua
+++ b/game/domain/effects/dmg_formula.lua
@@ -12,9 +12,9 @@ FX.schema = {
   { id = 'target', name = "Target", type = 'value', match = 'body' },
 }
 
-function FX.process (actor, sector, params)
+function FX.process (actor, params)
   local amount = RANDOM.rollDice(params.base, params.attr)
-  params.target:takeDamageFrom(amount, actor, sector)
+  params.target:takeDamageFrom(amount, actor)
 end
 
 return FX

--- a/game/domain/effects/draw_card.lua
+++ b/game/domain/effects/draw_card.lua
@@ -6,7 +6,7 @@ FX.schema = {
     range = {1} }, 
 }
 
-function FX.process (actor, sector, params)
+function FX.process (actor, params)
   for i = 1, params.amount do
     actor:drawCard()
   end 

--- a/game/domain/effects/heal.lua
+++ b/game/domain/effects/heal.lua
@@ -7,7 +7,7 @@ FX.schema = {
     range = {0} },
 }
 
-function FX.process (actor, sector, params)
+function FX.process (actor, params)
   params.target:heal(params.amount or 2)
 end
 

--- a/game/domain/effects/make_body.lua
+++ b/game/domain/effects/make_body.lua
@@ -14,7 +14,8 @@ FX.schema = {
     options = 'domains.card' },
 }
 
-function FX.process (actor, sector, params)
+function FX.process (actor, params)
+  local sector = actor:getBody():getSector()
   local bodyspec = params['bodyspec']
   local i,j = unpack(params['pos'])
   local body = sector:getRoute().makeBody(bodyspec, i, j)

--- a/game/domain/effects/modify_exp.lua
+++ b/game/domain/effects/modify_exp.lua
@@ -5,7 +5,7 @@ FX.schema = {
   { id = 'value', name = "Modify Exp By", type = 'value', match = 'integer' },
 }
 
-function FX.process(actor, sector, params)
+function FX.process(actor, params)
   actor:modifyExpBy(params.value)
 end
 

--- a/game/domain/effects/move_to.lua
+++ b/game/domain/effects/move_to.lua
@@ -6,8 +6,9 @@ FX.schema = {
   { id = 'pos', name = "Position", type = 'value', match = 'pos' }
 }
 
-function FX.process (actor, sector, params)
+function FX.process (actor, params)
   local pos = {actor:getPos()}
+  local sector = actor:getBody():getSector()
   sector:putBody(actor:getBody(), unpack(params.pos))
   coroutine.yield('report', {
     type = 'body_moved',

--- a/game/domain/effects/new_hand.lua
+++ b/game/domain/effects/new_hand.lua
@@ -5,7 +5,7 @@ FX.schema = {
   {id='nothing', type='none', name = "NO PARAM"}
 }
 
-function FX.process (actor, sector, params)
+function FX.process (actor, params)
   if actor:isHandEmpty() then
     for i = 1,actor:getHandLimit() do
       actor:drawCard()

--- a/game/domain/effects/place_widget_slot.lua
+++ b/game/domain/effects/place_widget_slot.lua
@@ -8,7 +8,7 @@ FX.schema = {
     match = "widget_slot" },
 }
 
-function FX.process(actor, sector, params)
+function FX.process(actor, params)
   actor:placeWidget(params.widget_slot, params.card)
 end
 

--- a/game/domain/effects/print.lua
+++ b/game/domain/effects/print.lua
@@ -6,7 +6,7 @@ FX.schema = {
     range = {0} }
 }
 
-function FX.process (actor, sector,params)
+function FX.process (actor,params)
   print(params.text)
 end
 

--- a/game/domain/effects/remove_actor_card.lua
+++ b/game/domain/effects/remove_actor_card.lua
@@ -9,7 +9,7 @@ FX.schema = {
     match = 'integer', range = {1} }, 
 }
 
-function FX.process (actor, sector, params)
+function FX.process (actor, params)
   local self = params['actor']
   local source = params['source']
   if source == 'HAND' then

--- a/game/domain/effects/spend_pp.lua
+++ b/game/domain/effects/spend_pp.lua
@@ -4,7 +4,7 @@ local FX = {}
 
 FX.schema = {}
 
-function FX.process (actor, sector, params)
+function FX.process (actor, params)
   actor:spendPP(DEFS.NEW_HAND_COST)
 end
 

--- a/game/domain/effects/upgrade_attribute.lua
+++ b/game/domain/effects/upgrade_attribute.lua
@@ -5,7 +5,7 @@ FX.schema = {
   { id = 'upgrade_list', name = "Upgrades", type = 'value', match = "upgrade-list" },
 }
 
-function FX.process(actor, sector, params)
+function FX.process(actor, params)
   for _,upgrade in ipairs(params.upgrade_list.actor) do
     local attr = upgrade.attr
     local val = upgrade.val

--- a/game/domain/maneuver/activate_widget.lua
+++ b/game/domain/maneuver/activate_widget.lua
@@ -27,9 +27,8 @@ function ACTIVATE.perform(actor, sector, params)
   actor:spendTime(widget:getWidgetActivationCost())
   actor:rewardPP(widget:getPPReward())
   ABILITY.execute(ability, actor, sector, params)
-  body:triggerWidgets(DEFS.TRIGGERS.ON_ANY_USE, sector,
-                      { activated_widget = widget })
-  body:triggerOneWidget(params.widget_slot, DEFS.TRIGGERS.ON_USE, sector)
+  body:triggerWidgets(DEFS.TRIGGERS.ON_ANY_USE, { activated_widget = widget })
+  body:triggerOneWidget(params.widget_slot, DEFS.TRIGGERS.ON_USE)
 end
 
 return ACTIVATE

--- a/game/domain/maneuver/activate_widget.lua
+++ b/game/domain/maneuver/activate_widget.lua
@@ -8,25 +8,25 @@ ACTIVATE.param_specs = {
   { output = 'widget_slot', typename = 'choose_widget_slot' }
 }
 
-function ACTIVATE.activatedAbility(actor, sector, params)
+function ACTIVATE.activatedAbility(actor, params)
   return actor:getBody():getWidget(params.widget_slot):getWidgetAbility()
 end
 
-function ACTIVATE.validate(actor, sector, params)
+function ACTIVATE.validate(actor, params)
   if not params.widget_slot then return false end
   local widget = actor:getBody():getWidget(params.widget_slot)
   if not widget then return false end
   local ability = widget:getWidgetAbility()
-  return ability and ABILITY.checkParams(ability, actor, sector, params)
+  return ability and ABILITY.checkParams(ability, actor, params)
 end
 
-function ACTIVATE.perform(actor, sector, params)
+function ACTIVATE.perform(actor, params)
   local body = actor:getBody()
   local widget = body:getWidget(params.widget_slot)
   local ability = widget:getWidgetAbility()
   actor:spendTime(widget:getWidgetActivationCost())
   actor:rewardPP(widget:getPPReward())
-  ABILITY.execute(ability, actor, sector, params)
+  ABILITY.execute(ability, actor, params)
   body:triggerWidgets(DEFS.TRIGGERS.ON_ANY_USE, { activated_widget = widget })
   body:triggerOneWidget(params.widget_slot, DEFS.TRIGGERS.ON_USE)
 end

--- a/game/domain/maneuver/consume_cards_from_buffer.lua
+++ b/game/domain/maneuver/consume_cards_from_buffer.lua
@@ -5,15 +5,15 @@ CONSUME.param_specs = {
   { output = 'consumed', typename = 'consume_list' },
 }
 
-function CONSUME.activatedAbility(actor, sector, params)
+function CONSUME.activatedAbility(actor, params)
   return nil
 end
 
-function CONSUME.validate(actor, sector, params)
+function CONSUME.validate(actor, params)
   return params.consumed
 end
 
-function CONSUME.perform(actor, sector, params)
+function CONSUME.perform(actor, params)
   for _,idx in ipairs(params.consumed) do
     local index = idx + actor:getBufferSize()+1
     local card = actor:getBackBufferCard(index)

--- a/game/domain/maneuver/draw_new_hand.lua
+++ b/game/domain/maneuver/draw_new_hand.lua
@@ -5,17 +5,17 @@ local DRAWHAND = {}
 
 DRAWHAND.param_specs = {}
 
-function DRAWHAND.activatedAbility(actor, sector, params)
+function DRAWHAND.activatedAbility(actor, params)
   return nil
 end
 
-function DRAWHAND.validate(actor, sector, params)
+function DRAWHAND.validate(actor, params)
   return not actor:isBufferEmpty()
          and actor:isHandEmpty()
          and actor:getPP() >= DEFS.ACTION.NEW_HAND_COST
 end
 
-function DRAWHAND.perform(actor, sector, params)
+function DRAWHAND.perform(actor, params)
   actor:spendPP(DEFS.ACTION.NEW_HAND_COST)
   for i = 1, DEFS.HAND_LIMIT do
     actor:drawCard()

--- a/game/domain/maneuver/idle.lua
+++ b/game/domain/maneuver/idle.lua
@@ -4,15 +4,15 @@ local IDLE = {}
 
 IDLE.param_specs = {}
 
-function IDLE.activatedAbility(actor, sector, params)
+function IDLE.activatedAbility(actor, params)
   return nil
 end
 
-function IDLE.validate(actor, sector, params)
+function IDLE.validate(actor, params)
   return true
 end
 
-function IDLE.perform(actor, sector, params)
+function IDLE.perform(actor, params)
   actor:spendTime(ACTIONDEFS.IDLE_TIME)
 end
 

--- a/game/domain/maneuver/interact.lua
+++ b/game/domain/maneuver/interact.lua
@@ -5,14 +5,15 @@ local INTERACT = {}
 INTERACT.param_specs = {
 }
 
-function INTERACT.activatedAbility(actor, sector, params)
+function INTERACT.activatedAbility(actor, params)
   return nil
 end
 
 -- FIXME: CHANGE_SECTOR should be an activated ability of interaction with
 --        stairs, portals, etc.
 
-local function _seek(actor, sector, params)
+local function _seek(actor, params)
+  local sector = actor:getBody():getSector()
   if not params.interaction then
     -- Try to go through exit
     local i, j = actor:getPos()
@@ -26,12 +27,12 @@ local function _seek(actor, sector, params)
   return params.interaction
 end
 
-function INTERACT.validate(actor, sector, params)
-  return not not _seek(actor, sector, params)
+function INTERACT.validate(actor, params)
+  return not not _seek(actor, params)
 end
 
-function INTERACT.perform(actor, sector, params)
-  _seek(actor, sector, params)
+function INTERACT.perform(actor, params)
+  _seek(actor, params)
   if params.interaction == 'CHANGE_SECTOR' then
     actor:spendTime(ACTIONDEFS.MOVE_TIME)
     local target_sector = Util.findId(params.sector)

--- a/game/domain/maneuver/move.lua
+++ b/game/domain/maneuver/move.lua
@@ -6,15 +6,17 @@ MOVE.param_specs = {
   { output = 'pos', typename = 'direction' },
 }
 
-function MOVE.activatedAbility(actor, sector, params)
+function MOVE.activatedAbility(actor, params)
   return nil
 end
 
-function MOVE.validate(actor, sector, params)
+function MOVE.validate(actor, params)
+  local sector = actor:getBody():getSector()
   return sector:isValid(unpack(params.pos))
 end
 
-function MOVE.perform(actor, sector, params)
+function MOVE.perform(actor, params)
+  local sector = actor:getBody():getSector()
   actor:spendTime(ACTIONDEFS.MOVE_TIME)
   local pos = {actor:getPos()}
   sector:putBody(actor:getBody(), unpack(params.pos))

--- a/game/domain/maneuver/play_card.lua
+++ b/game/domain/maneuver/play_card.lua
@@ -35,7 +35,7 @@ function PLAYCARD.perform(actor, sector, params)
   local card = _card(actor, params)
   local body = actor:getBody()
   actor:playCard(params.card_index)
-  body:triggerWidgets(TRIGGERS.ON_PLAY, sector, params)
+  body:triggerWidgets(TRIGGERS.ON_PLAY, params)
 
   if card:isArt() then
     actor:spendTime(card:getArtCost())

--- a/game/domain/maneuver/play_card.lua
+++ b/game/domain/maneuver/play_card.lua
@@ -13,16 +13,16 @@ local function _card(actor, params)
   return actor:getHandCard(params.card_index)
 end
 
-function PLAYCARD.activatedAbility(actor, sector, params)
+function PLAYCARD.activatedAbility(actor, params)
   local card = _card(actor, params)
   return card:isArt() and card:getArtAbility()
 end
 
-function PLAYCARD.validate(actor, sector, params)
+function PLAYCARD.validate(actor, params)
   local card = _card(actor, params)
   local valid = false
   if card:isArt() then
-    valid = ABILITY.checkParams(card:getArtAbility(), actor, sector, params)
+    valid = ABILITY.checkParams(card:getArtAbility(), actor, params)
   elseif card:isWidget() then
     valid = true
   elseif card:isUpgrade() then
@@ -31,7 +31,7 @@ function PLAYCARD.validate(actor, sector, params)
   return valid
 end
 
-function PLAYCARD.perform(actor, sector, params)
+function PLAYCARD.perform(actor, params)
   local card = _card(actor, params)
   local body = actor:getBody()
   actor:playCard(params.card_index)
@@ -40,7 +40,7 @@ function PLAYCARD.perform(actor, sector, params)
   if card:isArt() then
     actor:spendTime(card:getArtCost())
     actor:rewardPP(card:getPPReward())
-    ABILITY.execute(card:getArtAbility(), actor, sector, params)
+    ABILITY.execute(card:getArtAbility(), actor, params)
   elseif card:isWidget() then
     body:placeWidget(card)
   elseif card:isUpgrade() then

--- a/game/domain/maneuver/receive_pack.lua
+++ b/game/domain/maneuver/receive_pack.lua
@@ -6,15 +6,15 @@ RECEIVEPACK.param_specs = {
   { output = 'pack', typename = 'pack_list'}
 }
 
-function RECEIVEPACK.activatedAbility(actor, sector, params)
+function RECEIVEPACK.activatedAbility(actor, params)
   return nil
 end
 
-function RECEIVEPACK.validate(actor, sector, params)
+function RECEIVEPACK.validate(actor, params)
   return params.consumed and params.pack
 end
 
-function RECEIVEPACK.perform(actor, sector, params)
+function RECEIVEPACK.perform(actor, params)
   for _,card in ipairs(params.consumed) do
     actor:consumeCard(card)
   end

--- a/game/domain/maneuver/stash_card.lua
+++ b/game/domain/maneuver/stash_card.lua
@@ -12,15 +12,15 @@ local function _card(actor, params)
   return actor:getHandCard(params.card_index)
 end
 
-function STASH.activatedAbility(actor, sector, params)
+function STASH.activatedAbility(actor, params)
   return nil
 end
 
-function STASH.validate(actor, sector, params)
+function STASH.validate(actor, params)
   return not not _card(actor, params)
 end
 
-function STASH.perform(actor, sector, params)
+function STASH.perform(actor, params)
   local card = actor:removeHandCard(params.card_index)
   actor:addCardToBackbuffer(card)
   local stash_bonus = Card(STASH_CARDS[card:getRelatedAttr()])

--- a/game/domain/maneuver/use_signature.lua
+++ b/game/domain/maneuver/use_signature.lua
@@ -5,20 +5,19 @@ local SIGNATURE   = {}
 
 SIGNATURE.param_specs = {}
 
-function SIGNATURE.activatedAbility(actor, sector, params)
+function SIGNATURE.activatedAbility(actor, params)
   return actor:getSignature().ability
 end
 
-function SIGNATURE.validate(actor, sector, params)
-  return ABILITY.checkParams(actor:getSignature().ability, actor, sector,
-                             params)
+function SIGNATURE.validate(actor, params)
+  return ABILITY.checkParams(actor:getSignature().ability, actor, params)
 end
 
-function SIGNATURE.perform(actor, sector, params)
+function SIGNATURE.perform(actor, params)
   local signature = actor:getSignature()
   actor:spendTime(signature.cost)
   actor:rewardPP(signature.playpoints or 0)
-  ABILITY.execute(signature.ability, actor, sector, params)
+  ABILITY.execute(signature.ability, actor, params)
 end
 
 return SIGNATURE

--- a/game/domain/operators/dice_throw.lua
+++ b/game/domain/operators/dice_throw.lua
@@ -12,7 +12,7 @@ OP.schema = {
 
 OP.type = 'integer'
 
-function OP.process(actor, sector, params)
+function OP.process(actor, params)
   return RANDOM.rollDice(params.rolls, params.sides)
 end
 

--- a/game/domain/operators/get_actor_body.lua
+++ b/game/domain/operators/get_actor_body.lua
@@ -10,7 +10,7 @@ OP.schema = {
 
 OP.type = 'body'
 
-function OP.process(actor, sector, params)
+function OP.process(actor, params)
   return actor:getBody()
 end
 

--- a/game/domain/operators/get_actor_card.lua
+++ b/game/domain/operators/get_actor_card.lua
@@ -14,7 +14,7 @@ OP.schema = {
 
 OP.type = 'card'
 
-function OP.process(actor, sector, params)
+function OP.process(actor, params)
   local self = params['actor']
   local index = params['card-index']
   local source = params['source']

--- a/game/domain/operators/get_attribute.lua
+++ b/game/domain/operators/get_attribute.lua
@@ -11,7 +11,7 @@ OP.schema = {
 
 OP.type = 'integer'
 
-function OP.process(actor, sector, params)
+function OP.process(actor, params)
   return actor["get"..params.which](actor)
 end
 

--- a/game/domain/operators/get_body_at.lua
+++ b/game/domain/operators/get_body_at.lua
@@ -10,8 +10,8 @@ OP.schema = {
 
 OP.type = 'body'
 
-function OP.process(actor, sector, params)
-  return sector:getBodyAt(unpack(params.pos))
+function OP.process(actor, params)
+  return actor:getBody():getSector():getBodyAt(unpack(params.pos))
 end
 
 return OP

--- a/game/domain/operators/integer_binop.lua
+++ b/game/domain/operators/integer_binop.lua
@@ -12,7 +12,7 @@ OP.schema = {
 
 OP.type = 'integer'
 
-function OP.process(actor, sector, params)
+function OP.process(actor, params)
   if params.op == "+" then
     return params.lhs + params.rhs
   elseif params.op == "-" then

--- a/game/domain/operators/self.lua
+++ b/game/domain/operators/self.lua
@@ -9,7 +9,7 @@ OP.schema = {
 
 OP.type = 'actor'
 
-function OP.process(actor, sector, params)
+function OP.process(actor, params)
   return actor
 end
 

--- a/game/domain/params/body.lua
+++ b/game/domain/params/body.lua
@@ -9,7 +9,7 @@ PARAM.schema = {
 
 PARAM.type = 'body'
 
-function PARAM.isValid(sector, actor, parameter, value)
+function PARAM.isValid(actor, parameter, value)
   return true
 end
 

--- a/game/domain/params/card.lua
+++ b/game/domain/params/card.lua
@@ -9,7 +9,7 @@ PARAM.schema = {
 
 PARAM.type = 'card'
 
-function PARAM.isValid(sector, actor, parameter, value)
+function PARAM.isValid(actor, parameter, value)
   return true
 end
 

--- a/game/domain/params/card_index.lua
+++ b/game/domain/params/card_index.lua
@@ -9,7 +9,7 @@ PARAM.schema = {
 
 PARAM.type = 'integer'
 
-function PARAM.isValid(sector, actor, parameter, value)
+function PARAM.isValid(actor, parameter, value)
   return true
 end
 

--- a/game/domain/params/choose_target.lua
+++ b/game/domain/params/choose_target.lua
@@ -12,7 +12,7 @@ PARAM.schema = {
 
 PARAM.type = 'pos'
 
-function PARAM.isWithinRange(sector, actor, parameter, value)
+function PARAM.isWithinRange(actor, parameter, value)
   local max = parameter['max-range'] if max then
     local i,j = actor:getPos()
     local dist = TILE.dist(i,j,unpack(value))
@@ -23,14 +23,15 @@ function PARAM.isWithinRange(sector, actor, parameter, value)
   return true
 end
 
-function PARAM.isValid(sector, actor, parameter, value)
+function PARAM.isValid(actor, parameter, value)
+  local sector = actor:getBody():getSector()
   if not sector:isInside(unpack(value)) then
     return false
   end
   if parameter['body-only'] and not sector:getBodyAt(unpack(value)) then
     return false
   end
-  if not PARAM.isWithinRange(sector, actor, parameter, value) then
+  if not PARAM.isWithinRange(actor, parameter, value) then
     return false
   end
   local i, j = unpack(value)

--- a/game/domain/params/choose_widget_slot.lua
+++ b/game/domain/params/choose_widget_slot.lua
@@ -7,7 +7,7 @@ PARAM.schema = {
 
 PARAM.type = 'widget_slot'
 
-function PARAM.isValid(sector, actor, parameter, value)
+function PARAM.isValid(actor, parameter, value)
   if not actor:getBody():hasWidgetAt(value) then
     return false
   end

--- a/game/domain/params/direction.lua
+++ b/game/domain/params/direction.lua
@@ -7,7 +7,7 @@ PARAM.schema = {
 
 PARAM.type = 'pos'
 
-function PARAM.isValid(sector, actor, parameter, value)
+function PARAM.isValid(actor, parameter, value)
   return true
 end
 

--- a/game/domain/params/empty_hand.lua
+++ b/game/domain/params/empty_hand.lua
@@ -7,7 +7,7 @@ PARAM.schema = {
 
 PARAM.type = 'boolean'
 
-function PARAM.isValid(sector, actor, parameter, value)
+function PARAM.isValid(actor, parameter, value)
   return actor:isHandEmpty()
 end
 

--- a/game/domain/params/has_enough_pp.lua
+++ b/game/domain/params/has_enough_pp.lua
@@ -8,7 +8,7 @@ PARAM.schema = {
 
 PARAM.type = 'none'
 
-function PARAM.isValid(sector, actor, parameter, value)
+function PARAM.isValid(actor, parameter, value)
   return actor:getPP() >= DEFS.NEW_HAND_COST
 end
 

--- a/game/domain/params/pack_card.lua
+++ b/game/domain/params/pack_card.lua
@@ -7,7 +7,7 @@ PARAM.schema = {
 
 PARAM.type = 'card'
 
-function PARAM.isValid(sector, actor, parameter, value)
+function PARAM.isValid(actor, parameter, value)
   return true
 end
 

--- a/game/domain/params/same_card.lua
+++ b/game/domain/params/same_card.lua
@@ -9,7 +9,7 @@ PARAM.schema = {
 
 PARAM.type = 'boolean'
 
-function PARAM.isValid(sector, actor, parameter, value)
+function PARAM.isValid(actor, parameter, value)
   local lhs, rhs = parameter['lhs'], parameter['rhs']
   local op = parameter['op']
   return lhs == rhs

--- a/game/domain/params/sector.lua
+++ b/game/domain/params/sector.lua
@@ -7,7 +7,7 @@ PARAM.schema = {
 
 PARAM.type = 'sector'
 
-function PARAM.isValid(sector, actor, parameter, value)
+function PARAM.isValid(actor, parameter, value)
   return true
 end
 

--- a/game/domain/params/upgrade_cost.lua
+++ b/game/domain/params/upgrade_cost.lua
@@ -7,7 +7,7 @@ PARAM.schema = {
 
 PARAM.type = 'integer'
 
-function PARAM.isValid(sector, actor, parameter, value)
+function PARAM.isValid(actor, parameter, value)
   return actor:getExp() >= value
 end
 

--- a/game/domain/params/upgrade_list.lua
+++ b/game/domain/params/upgrade_list.lua
@@ -7,7 +7,7 @@ PARAM.schema = {
 
 PARAM.type = 'upgrade-list'
 
-function PARAM.isValid(sector, actor, parameter, value)
+function PARAM.isValid(actor, parameter, value)
   return true
 end
 

--- a/game/domain/sector.lua
+++ b/game/domain/sector.lua
@@ -425,7 +425,7 @@ function _turnLoop(self, ...)
 
       if actor:ready() then
         while actor:ready() do
-          actor:makeAction(self)
+          actor:makeAction()
           manageDeadBodiesAndUpdateActorsQueue(self, actors_queue)
         end
         actor:turn()

--- a/game/gamestates/user_turn.lua
+++ b/game/gamestates/user_turn.lua
@@ -144,8 +144,7 @@ local function _useAction(action_slot, params)
   local current_sector = _route.getCurrentSector()
   local controlled_actor = _route.getControlledActor()
   params = params or {}
-  local param = ACTION.pendingParam(action_slot, controlled_actor,
-                                    current_sector, params)
+  local param = ACTION.pendingParam(action_slot, controlled_actor, params)
   while param do
     if param.typename == 'choose_target' then
       SWITCHER.push(
@@ -154,12 +153,11 @@ local function _useAction(action_slot, params)
           pos = { controlled_actor:getPos() },
           range_checker = function(i, j)
             return ABILITY.param('choose_target')
-                          .isWithinRange(current_sector, controlled_actor,
-                                        param, {i,j})
+                          .isWithinRange(controlled_actor, param, {i,j})
           end,
           validator = function(i, j)
-            return ABILITY.validate('choose_target', current_sector,
-                                    controlled_actor, param, {i,j})
+            return ABILITY.validate('choose_target', controlled_actor, param,
+                                    {i,j})
           end
         }
       )
@@ -173,8 +171,8 @@ local function _useAction(action_slot, params)
       SWITCHER.push(
         GS.PICK_WIDGET_SLOT, controlled_actor,
         function (which_slot)
-          return ABILITY.validate('choose_widget_slot', current_sector,
-                                  controlled_actor, param, which_slot)
+          return ABILITY.validate('choose_widget_slot', controlled_actor, param,
+                                  which_slot)
         end
       )
       local args = coroutine.yield(_task)
@@ -184,8 +182,7 @@ local function _useAction(action_slot, params)
         return false
       end
     end
-    param = ACTION.pendingParam(action_slot, controlled_actor,
-                                current_sector, params)
+    param = ACTION.pendingParam(action_slot, controlled_actor, params)
   end
   _next_action = {action_slot, params}
   return true


### PR DESCRIPTION
It seems we all forgot for a long time that bodies have a `getSector()` method. Since actors also have a `getBody()` getter, this means A LOT of functions and methods in the code base did not need to receive both an actor and the sector as arguments.

This PR cleans that up. Please test.