### PR TITLE
Card/trivial cards

### DIFF
--- a/game/database/domains/actor/arcanist.json
+++ b/game/database/domains/actor/arcanist.json
@@ -5,25 +5,13 @@
   "cor":-4,
   "initial_buffer":[{
       "amount":1,
-      "card":"arc_1"
-    },{
-      "amount":1,
       "card":"teleport"
     },{
-      "amount":1,
+      "amount":2,
       "card":"fireball"
     },{
-      "amount":1,
-      "card":"firebolt"
-    },{
       "amount":8,
-      "card":"soul_robe"
-    },{
-      "amount":4,
-      "card":"divination"
-    },{
-      "amount":4,
-      "card":"haste"
+      "card":"stick_flame"
     }],
   "ani":-4,
   "name":"Arcanist",

--- a/game/database/domains/actor/arcanist.json
+++ b/game/database/domains/actor/arcanist.json
@@ -3,8 +3,6 @@
   "arc":4,
   "signature":"BOLT",
   "cor":-4,
-  "name":"Arcanist",
-  "ani":-4,
   "initial_buffer":[{
       "amount":1,
       "card":"arc_1"
@@ -18,8 +16,8 @@
       "amount":1,
       "card":"firebolt"
     },{
-      "amount":6,
-      "card":"focus"
+      "amount":8,
+      "card":"soul_robe"
     },{
       "amount":4,
       "card":"divination"
@@ -27,5 +25,7 @@
       "amount":4,
       "card":"haste"
     }],
+  "ani":-4,
+  "name":"Arcanist",
   "description":"After years of effort and study, you have\nbecome proficient in the arcane arts passed down\nsince time immemorial. You strongly believe there\nis nothing the power of your magic cannot achieve,\nso long as you have the time to prepare."
 }

--- a/game/database/domains/actor/brawler.json
+++ b/game/database/domains/actor/brawler.json
@@ -3,8 +3,6 @@
   "arc":-4,
   "signature":"STRIKE",
   "cor":4,
-  "name":"Brawler",
-  "ani":-4,
   "initial_buffer":[{
       "amount":1,
       "card":"vit_1"
@@ -31,7 +29,9 @@
       "card":"dropkick"
     },{
       "amount":8,
-      "card":"seedling-sap"
+      "card":"calming_down"
     }],
+  "ani":-4,
+  "name":"Brawler",
   "description":"You find that close-quarter skirmishes and martial\narts in general suit your tastes and abilities\nrather well. Anything that does not involve\nbreaking things is a test to your patience."
 }

--- a/game/database/domains/card/calming_down.json
+++ b/game/database/domains/card/calming_down.json
@@ -1,0 +1,30 @@
+{
+  "attr":"ANI",
+  "widget":{
+    "operators":[],
+    "trigger":"on_act",
+    "charges":2,
+    "auto_activation":{
+      "trigger":"on_tick",
+      "ability":{
+        "params":[],
+        "operators":[{
+            "typename":"self",
+            "output":"self_actor"
+          },{
+            "typename":"get_actor_body",
+            "output":"actor_body",
+            "actor":"val:self_actor"
+          }],
+        "effects":[{
+            "typename":"heal",
+            "target":"val:actor_body",
+            "amount":1
+          }]
+      }
+    }
+  },
+  "desc":"This user is regenerating 2 health each tick. However, doing anything besides moving or waiting will remove this status.",
+  "pp":4,
+  "name":"Calming Down"
+}

--- a/game/database/domains/card/soul_robe.json
+++ b/game/database/domains/card/soul_robe.json
@@ -1,0 +1,21 @@
+{
+  "attr":"ANI",
+  "widget":{
+    "operators":[{
+        "attr":"ANI",
+        "op":"+",
+        "val":3
+      }],
+    "trigger":"on_act",
+    "charges":5,
+    "trigger-condition":{
+      "params":[],
+      "operators":[],
+      "effects":[]
+    },
+    "placement":"suit"
+  },
+  "desc":"Buffs your ANI by 4. Has 5 charges, spends one everytime you act.",
+  "pp":3,
+  "name":"Soul Robe"
+}

--- a/game/database/domains/card/stick_flame.json
+++ b/game/database/domains/card/stick_flame.json
@@ -1,0 +1,28 @@
+{
+  "desc":"Place a Sticky Flame on target body. After a few ticks, the Sticky Flame will explode, dealing 2d(4*ARC) damage to the body holding it.\n\n\"'Hey Danny, hold this for me, will ya?'. - Robert was surprised Danny didn't sent him an invite for his birthday the week after.\"",
+  "attr":"ARC",
+  "pp":4,
+  "name":"Stick Flame",
+  "art":{
+    "art_ability":{
+      "params":[{
+          "aoe-hint":1,
+          "max-range":4,
+          "typename":"choose_target",
+          "output":"target_pos",
+          "body-only":[]
+        }],
+      "operators":[{
+          "typename":"get_body_at",
+          "pos":"par:target_pos",
+          "output":"target_body"
+        }],
+      "effects":[{
+          "typename":"place_widget",
+          "body":"val:target_body",
+          "card":"sticky_flame"
+        }]
+    },
+    "cost":40
+  }
+}

--- a/game/database/domains/card/sticky_flame.json
+++ b/game/database/domains/card/sticky_flame.json
@@ -1,0 +1,37 @@
+{
+  "desc":"This widget spends charges every tick. When out of charges, it will explode dealing 2d(4*ARC) damage to self, where ARC is the original caster ARC.",
+  "widget":{
+    "operators":[],
+    "trigger":"on_tick",
+    "activation":false,
+    "charges":40,
+    "auto_activation":{
+      "ability":{
+        "params":[{
+            "typename":"body",
+            "output":"body_self"
+          }],
+        "operators":[{
+            "typename":"get_attribute",
+            "output":"ARC",
+            "which":"ARC"
+          },{
+            "op":"*",
+            "typename":"integer_binop",
+            "lhs":"val:ARC",
+            "output":"ARC*4",
+            "rhs":4
+          }],
+        "effects":[{
+            "typename":"damage_on_target",
+            "target":"par:body_self",
+            "base":"val:ARC*4",
+            "attr":2
+          }]
+      },
+      "trigger":"on_done"
+    }
+  },
+  "attr":"ARC",
+  "name":"Sticky Flame"
+}

--- a/game/domain/effects/place_widget.lua
+++ b/game/domain/effects/place_widget.lua
@@ -10,7 +10,9 @@ FX.schema = {
 }
 
 function FX.process(actor, params)
-  params['body']:placeWidget(Card(params['card']))
+  local card = Card(params['card'])
+  card:setOwner(actor)
+  params['body']:placeWidget(card)
 end
 
 return FX

--- a/game/domain/operators/get_body_pos.lua
+++ b/game/domain/operators/get_body_pos.lua
@@ -15,4 +15,3 @@ function OP.process(actor, params)
 end
 
 return OP
-


### PR DESCRIPTION
Added card Calming Down (old Meditate) dor Brawler (#465)

Added cards Soul Robe and Stick Flame for Arcanist (#467)

For trivial cards still need to make Reassemble, but will do at another PR.

NOTE: For card Calming Down, had to add 2 charges instead of 1, since it will spend the first one when you cast the card (using on_act trigger). We should fix this in another commit so we can make it with only one charge