### PR TITLE
Feature: db refresh

### DIFF
--- a/game/database/init.lua
+++ b/game/database/init.lua
@@ -95,18 +95,38 @@ local function _save(cache, basepath)
       local meta = getmetatable(subcache) or {}
       local item = meta.group or group
       local newbasepath = basepath.."/"..item
-      if subcache == DEFS.DELETE then
-        cache[group] = nil
-        _deleteFile(newbasepath..".json")
-      else
-        _save(subcache, newbasepath)
-      end
+      _save(subcache, newbasepath)
     end
   else
     -- save file
     local filepath = basepath..".json"
     return assert(_writeFile(filepath, cache))
   end
+end
+
+local function _refresh(cache, basepath)
+  -- check whether we are saving a group of files or a file
+  if getmetatable(cache).is_leaf then return end
+  -- save group
+  for group, subcache in pairs(cache) do
+    local meta = getmetatable(subcache) or {}
+    local item = meta.group or group
+    local newbasepath = basepath.."/"..item
+    if subcache == DEFS.DELETE then
+      cache[group] = nil
+      _deleteFile(newbasepath..".json")
+    else
+      _refresh(subcache, newbasepath)
+    end
+  end
+  --[[--
+  -- HARD REFRESH --
+  local group
+  repeat
+    group = next(cache)
+    cache[group] = nil
+  until next(cache) == nil
+  --]]--
 end
 
 function _listItemsIn(category, group_name)
@@ -227,9 +247,16 @@ function DB.listItemsIn(category, group)
   return _listItemsIn(category, group)
 end
 
+function DB.refresh(container)
+  container = container or _dbcache
+  local basepath = getmetatable(container).relpath
+  _refresh(container, basepath)
+end
+
 function DB.save(container)
   container = container or _dbcache
   local basepath = getmetatable(container).relpath
+  _refresh(container, basepath)
   _save(container, basepath)
 end
 

--- a/game/database/init.lua
+++ b/game/database/init.lua
@@ -119,14 +119,12 @@ local function _refresh(cache, basepath)
       _refresh(subcache, newbasepath)
     end
   end
-  --[[--
   -- HARD REFRESH --
   local group
   repeat
     group = next(cache)
-    cache[group] = nil
+    if group then cache[group] = nil end
   until next(cache) == nil
-  --]]--
 end
 
 function _listItemsIn(category, group_name)

--- a/game/debug/gui.lua
+++ b/game/debug/gui.lua
@@ -141,6 +141,9 @@ function GUI:draw()
         end
       end
       IMGUI.Separator()
+      if IMGUI.MenuItem("Refresh") then
+        DB.refresh(DB.loadCategory('domains'))
+      end
       if IMGUI.MenuItem("Save") then
         DB.save(DB.loadCategory('domains'))
       end
@@ -154,6 +157,9 @@ function GUI:draw()
         end
       end
       IMGUI.Separator()
+      if IMGUI.MenuItem("Refresh") then
+        DB.refresh(DB.loadCategory('resources'))
+      end
       if IMGUI.MenuItem("Save") then
         DB.save(DB.loadCategory('resources'))
       end


### PR DESCRIPTION
You can now press the refresh button to remove all cache and hard-delete all deleted entries from DB.

This means that you do not have to save all domains just to rename a single file anymore, and this makes updating sprites, textures, and fonts on the fly much easier too.