### PR TITLE
Remove ON_ACT trigger for playing widgets and upgrades

### DIFF
--- a/game/database/domains/card/calming_down.json
+++ b/game/database/domains/card/calming_down.json
@@ -3,7 +3,7 @@
   "widget":{
     "operators":[],
     "trigger":"on_act",
-    "charges":2,
+    "charges":1,
     "auto_activation":{
       "trigger":"on_tick",
       "ability":{

--- a/game/domain/maneuver/play_card.lua
+++ b/game/domain/maneuver/play_card.lua
@@ -40,6 +40,7 @@ function PLAYCARD.perform(actor, params)
     actor:spendTime(card:getArtCost())
     actor:rewardPP(card:getPPReward())
     ABILITY.execute(card:getArtAbility(), actor, params)
+    body:triggerWidgets(TRIGGERS.ON_ACT)
   elseif card:isWidget() then
     body:placeWidget(card)
   elseif card:isUpgrade() then
@@ -59,7 +60,6 @@ function PLAYCARD.perform(actor, params)
     end
   end
 
-  body:triggerWidgets(TRIGGERS.ON_ACT)
   body:triggerWidgets(TRIGGERS.ON_PLAY, { card = card })
 end
 


### PR DESCRIPTION
Also fix "Calming Down" card to have only one charge.

Close #518 