### PR TITLE
Fix: default values

### DIFF
--- a/game/database/domains/action/MELEE.json
+++ b/game/database/domains/action/MELEE.json
@@ -1,4 +1,5 @@
 {
+  "playpoints":3,
   "cost":6,
   "ability":{
     "operators":[{
@@ -11,19 +12,21 @@
         "output":"target_body"
       }],
     "params":[{
-        "typename":"choose_target",
-        "body-only":{
-          "body-type":"<none>"
-        },
+        "aoe-hint":0,
+        "non-wall":false,
         "output":"target",
+        "typename":"choose_target",
+        "empty-tile":false,
+        "body-only":{
+          "body-type":false
+        },
         "max-range":1
       }],
     "effects":[{
         "typename":"damage_on_target",
         "target":"val:target_body",
-        "base":4,
-        "attr":"val:cor"
+        "attr":"val:cor",
+        "base":4
       }]
-  },
-  "playpoints":3
+  }
 }

--- a/game/database/domains/card/summon.json
+++ b/game/database/domains/card/summon.json
@@ -1,24 +1,32 @@
 {
-  "desc":"",
   "attr":"ARC",
-  "name":"Sample Bot",
+  "icon":false,
+  "set":false,
   "art":{
     "cost":20,
     "art_ability":{
       "params":[{
+          "aoe-hint":0,
+          "max-range":1,
           "typename":"choose_target",
+          "non-wall":false,
           "output":"pos",
-          "max-range":1
+          "empty-tile":false
         }],
       "operators":[],
       "effects":[{
+          "widgets":[],
           "pos":"par:pos",
-          "vit":0,
-          "typename":"make_body",
-          "widgetspec":"<none>",
           "def":50,
-          "bodyspec":"machine"
+          "typename":"make_body",
+          "bodyspec":"machine",
+          "vit":0
         }]
     }
-  }
+  },
+  "desc":"",
+  "type-description":"",
+  "pp":0,
+  "name":"Sample Bot",
+  "one_time":false
 }

--- a/game/debug/view/input/common.lua
+++ b/game/debug/view/input/common.lua
@@ -10,6 +10,7 @@ local function _makeCommon(default, call)
         IMGUI.Text(key.name)
       end
       local value = spec[key.id] or default
+      spec[key.id] = value
       IMGUI.PushID(key.id)
       local changed, newvalue = call(value, key)
       IMGUI.PopID()
@@ -28,7 +29,7 @@ inputs.boolean = _makeCommon(
 )
 
 inputs.integer = _makeCommon(
-  nil,
+  0,
   function(value, key)
     value = value or (key.range or {0})[1]
     local range = key.range

--- a/game/debug/view/input/enum.lua
+++ b/game/debug/view/input/enum.lua
@@ -36,6 +36,12 @@ function inputs.enum(spec, key)
 
   local _active = not (not spec[key.id] and key.optional)
 
+  if _active and _options[_current] ~= _NONE then
+    spec[key.id] = spec[key.id] or _options[_current]
+  else
+    spec[key.id] = false
+  end
+
   return function(self)
     if key.optional then
       IMGUI.PushID(key.id .. ".check")
@@ -50,7 +56,11 @@ function inputs.enum(spec, key)
       IMGUI.PopID()
       if changed then
         _current = value
-        spec[key.id] = _options[value]
+        if _options[value] == _NONE then
+          spec[key.id] = false
+        else
+          spec[key.id] = _options[value]
+        end
       end
     end
   end

--- a/game/debug/view/input/vector.lua
+++ b/game/debug/view/input/vector.lua
@@ -17,12 +17,13 @@ function inputs.vector(spec, key)
   local selected = nil
   local size = key.size
   local range = key.range
+  local default = key.default or 0
   local signature = setmetatable(key.signature or
                                  {'x','y','z','w'},
                                  signature_mt)
   local subschemas = {}
   for i=1, size do
-    vector[i] = vector[i] or 0
+    vector[i] = vector[i] or default
     local subkey = {
       id = i,
       name = signature[i],

--- a/game/domain/body.lua
+++ b/game/domain/body.lua
@@ -84,7 +84,7 @@ end
 --[[ Spec-related methods ]]--
 
 function Body:isSpec(specname)
-  if not specname or specname == '<none>' then
+  if not specname then
     return true
   end
   local actual_specname = self:getSpecName()
@@ -96,7 +96,7 @@ function Body:isSpec(specname)
       break
     end
     actual_specname = parent
-  until not parent or parent == '<none>'
+  until not parent
   return ok
 end
 

--- a/game/domain/effects/make_body.lua
+++ b/game/domain/effects/make_body.lua
@@ -28,7 +28,7 @@ function FX.process (actor, params)
   state.widgets = {}
   for _,widget_params in ipairs(params['widgets']) do
     local widgetspec = widget_params['spec']
-    if type(widgetspec) == 'string' and widgetspec ~= '<none>' then
+    if widgetspec then
       local widget = Card(widgetspec)
       assert(widget:isWidget())
       widget:setOwner(actor)

--- a/game/domain/params/choose_target.lua
+++ b/game/domain/params/choose_target.lua
@@ -47,7 +47,7 @@ function PARAM.isValid(actor, parameter, value)
       return false
     end
     local typename = parameter['body-only']['body-type']
-    if typename and typename ~= '<none>' and not body:isSpec(typename) then
+    if typename and not body:isSpec(typename) then
       return false
     end
   end


### PR DESCRIPTION
This makes inputs in the specification editor to default to a certain value when they are loaded the first time. This fixes some random issues of values looking like they are set to zero but are actually invalid (`nil`).

But most importantly this makes the default value to unset enums to `false`. So when you first load an enum input, it defaults to false AND if you set it manually to `"<none>"`, it BECOMES false, and not literally the `"<none>"` string. This makes verifications to the `"<none>"` value completely unnecessary, so I went ahead and removed them.