### PR TITLE
Fix camzoom bug, enhance a few inputs

### DIFF
--- a/game/database/settings/controls.json
+++ b/game/database/settings/controls.json
@@ -4,7 +4,7 @@
     "ACTION_2":["e"],
     "ACTION_3":["w"],
     "ACTION_4":["q"],
-    "CONFIRM":["f"],
+    "CONFIRM":["f", true, "return"],
     "CANCEL":["d"],
     "SPECIAL":["s"],
     "EXTRA":["a"],

--- a/game/gamestates/card_select.lua
+++ b/game/gamestates/card_select.lua
@@ -74,6 +74,7 @@ function state:update(dt)
   elseif INPUT.wasActionPressed('CONFIRM') then
     _confirmCard()
   elseif INPUT.wasActionPressed('CANCEL') or
+    INPUT.wasActionPressed('ACTION_1') or
     INPUT.wasActionPressed('SPECIAL') then
     _cancel()
   end

--- a/game/gamestates/user_turn.lua
+++ b/game/gamestates/user_turn.lua
@@ -112,7 +112,11 @@ function state:update(dt)
     elseif INPUT.wasActionPressed('SPECIAL') then
       _startTask(DEFS.ACTION.USE_SIGNATURE)
     elseif INPUT.wasActionPressed('ACTION_1') then
-      _startTask(DEFS.ACTION.PLAY_CARD)
+      if _route.getControlledActor():isHandEmpty() then
+        _startTask(DEFS.ACTION.DRAW_NEW_HAND)
+      else
+        _startTask(DEFS.ACTION.PLAY_CARD)
+      end
     elseif INPUT.wasActionPressed('EXTRA') then
       return SWITCHER.push(GS.ACTION_MENU, _route)
     elseif INPUT.wasActionPressed('PAUSE') then

--- a/game/view/actionmenu.lua
+++ b/game/view/actionmenu.lua
@@ -116,6 +116,7 @@ function ActionMenu:close()
   self:addTimer(_TWEEN.OPEN_CLOSE, MAIN_TIMER, "tween", 0.3,
                 self, { enter = 0 }, 'out-circ', function()
                   self.invisible = true
+                  CAM:zoomTo(1)
                 end
   )
   self:hideLabel()


### PR DESCRIPTION
Closes #557, **probably**

Also add 'return' as available key to CONFIRM action, allow drawing new cards with ACTION_1 action, and allow closing handview with ACTION_1 as well.