### PR TITLE
Rebalanced gadgeteer's stuff

### DIFF
--- a/game/database/domains/action/bullet.json
+++ b/game/database/domains/action/bullet.json
@@ -1,4 +1,5 @@
 {
+  "playpoints":0,
   "ability":{
     "operators":[{
         "typename":"self",
@@ -38,9 +39,8 @@
         "size":1,
         "typename":"damage_on_area",
         "ignore_owner":false,
-        "base":5
+        "base":6
       }]
   },
-  "cost":20,
-  "playpoints":0
+  "cost":20
 }

--- a/game/database/domains/card/jetboots.json
+++ b/game/database/domains/card/jetboots.json
@@ -4,10 +4,14 @@
   "one_time":false,
   "desc":"Allows you to dash in straight lines.",
   "type-description":"",
+  "set":false,
+  "pp":0,
+  "name":"Jetboots",
   "widget":{
     "operators":[],
     "trigger":"on_use",
     "activation":{
+      "cost":10,
       "ability":{
         "params":[{
             "typename":"choose_dir",
@@ -30,7 +34,7 @@
             "dir":"par:dir",
             "typename":"hitscan",
             "output":"target-pos",
-            "maxrange":8
+            "maxrange":5
           }],
         "effects":[{
             "pos":"val:target-pos",
@@ -39,14 +43,10 @@
             "body":"val:body",
             "vfx-spd":1
           }]
-      },
-      "cost":10
+      }
     },
     "charges":8,
     "status-tags":[],
     "placement":false
-  },
-  "pp":0,
-  "name":"Jetboots",
-  "set":false
+  }
 }

--- a/game/database/domains/card/proximity-detector.json
+++ b/game/database/domains/card/proximity-detector.json
@@ -4,12 +4,10 @@
   "one_time":true,
   "desc":"Don't stand so close to me!",
   "type-description":"",
-  "set":false,
-  "pp":0,
-  "name":"Proximity Detector",
   "widget":{
     "operators":[],
     "trigger":"on_tick",
+    "status-tags":[],
     "charges":1,
     "trigger-condition":{
       "params":[{
@@ -18,17 +16,16 @@
         },{
           "ignore-owner":true,
           "body-type":false,
-          "range":3,
+          "pos":"par:pos_self",
           "typename":"has_nearby_bodies",
           "count":1,
-          "output":"yup",
-          "pos":"par:pos_self"
+          "range":3,
+          "output":"yup"
         }],
       "operators":[],
       "effects":[]
     },
     "auto_activation":{
-      "trigger":"on_done",
       "ability":{
         "params":[{
             "typename":"body",
@@ -49,13 +46,17 @@
           },{
             "attr":"val:cor",
             "center":"val:pos",
-            "size":4,
+            "size":2,
             "typename":"damage_on_area",
-            "ignore_owner":true,
-            "base":10
+            "ignore_owner":false,
+            "base":16
           }]
-      }
+      },
+      "trigger":"on_done"
     },
     "placement":false
-  }
+  },
+  "pp":0,
+  "name":"Proximity Detector",
+  "set":false
 }

--- a/game/database/domains/card/self-destruct.json
+++ b/game/database/domains/card/self-destruct.json
@@ -1,11 +1,13 @@
 {
   "attr":"ARC",
-  "one_time":true,
+  "icon":false,
   "widget":{
     "operators":[],
     "trigger":"on_cycle",
     "charges":8,
+    "status-tags":[],
     "auto_activation":{
+      "trigger":"on_done",
       "ability":{
         "params":[{
             "typename":"body",
@@ -28,14 +30,19 @@
             "center":"val:pos",
             "size":3,
             "typename":"damage_on_area",
-            "base":10
+            "ignore_owner":false,
+            "base":12
           },{
             "typename":"destroy_body",
             "target":"par:body_self"
           }]
-      },
-      "trigger":"on_done"
-    }
+      }
+    },
+    "placement":false
   },
-  "name":"Self Destruction"
+  "desc":"",
+  "type-description":"",
+  "one_time":true,
+  "name":"Self Destruction",
+  "set":false
 }

--- a/game/database/domains/card/sensor-bomb.json
+++ b/game/database/domains/card/sensor-bomb.json
@@ -5,12 +5,12 @@
   "art":{
     "art_ability":{
       "params":[{
-          "aoe-hint":4,
+          "aoe-hint":2,
           "max-range":1,
           "typename":"choose_target",
-          "empty-tile":true,
+          "non-wall":true,
           "output":"pos",
-          "non-wall":true
+          "empty-tile":true
         }],
       "operators":[],
       "effects":[{
@@ -19,12 +19,12 @@
             }],
           "pos":"par:pos",
           "typename":"make_body",
-          "def":50,
           "bodyspec":"machine",
-          "vit":50
+          "vit":50,
+          "def":50
         }]
     },
-    "cost":60
+    "cost":40
   },
   "desc":"Kaboom",
   "type-description":"",

--- a/game/database/domains/card/turret.json
+++ b/game/database/domains/card/turret.json
@@ -3,13 +3,13 @@
   "icon":"card-turret",
   "set":false,
   "art":{
-    "cost":60,
+    "cost":100,
     "art_ability":{
       "params":[{
           "aoe-hint":4,
-          "empty-tile":true,
-          "typename":"choose_target",
           "non-wall":true,
+          "typename":"choose_target",
+          "empty-tile":true,
           "output":"pos",
           "max-range":1
         }],
@@ -17,14 +17,12 @@
       "effects":[{
           "widgets":[{
               "spec":"auto-fire"
-            },{
-              "spec":"battery"
             }],
           "pos":"par:pos",
           "typename":"make_body",
-          "vit":50,
           "def":50,
-          "bodyspec":"machine"
+          "bodyspec":"machine",
+          "vit":50
         }]
     }
   },

--- a/game/database/domains/card/wrench.json
+++ b/game/database/domains/card/wrench.json
@@ -4,20 +4,16 @@
   "set":false,
   "desc":"Deal XdCOR damage where X=5+nearby machines",
   "type-description":"",
-  "one_time":false,
-  "pp":0,
-  "name":"Wrench",
   "widget":{
     "operators":[],
     "trigger":"on_use",
     "activation":{
-      "cost":20,
       "ability":{
         "params":[{
             "typename":"choose_target",
-            "max-range":1,
+            "body-only":[],
             "output":"pos",
-            "body-only":[]
+            "max-range":1
           }],
         "operators":[{
             "typename":"get_attribute",
@@ -38,15 +34,15 @@
             "ignore-owner":true,
             "pos":"val:center",
             "typename":"count_nearby_bodies",
-            "body-type":"machine",
+            "output":"count",
             "range":5,
-            "output":"count"
+            "body-type":"machine"
           },{
             "op":"+",
             "typename":"integer_binop",
-            "rhs":5,
+            "lhs":"val:count",
             "output":"base",
-            "lhs":"val:count"
+            "rhs":7
           },{
             "typename":"get_body_at",
             "pos":"par:pos",
@@ -55,13 +51,17 @@
         "effects":[{
             "typename":"damage_on_target",
             "target":"val:target",
-            "base":"val:base",
-            "attr":"val:cor"
+            "attr":"val:cor",
+            "base":"val:base"
           }]
-      }
+      },
+      "cost":20
     },
     "charges":10,
     "status-tags":[],
     "placement":"weapon"
-  }
+  },
+  "pp":0,
+  "name":"Wrench",
+  "one_time":false
 }


### PR DESCRIPTION
Most notably:
1. Turret is now undying. Gadgetter still suffers a lot, so I see no problem with this. Besides, it encourages different gameplay styles
2. Explosion drones all harm the owner, but their size and cost has been adjusted to account that
3. Jetboots range was reduced
4. Reinforce is useless, we need to do something about it