### PR TITLE
Fix camera lock when changing sectors

### DIFF
--- a/game/domain/route.lua
+++ b/game/domain/route.lua
@@ -135,18 +135,15 @@ function Route:instance(obj)
     local player_sector = obj.getPlayerActor():getBody():getSector()
     if player_sector ~= _current_sector then
       obj.setCurrentSector(player_sector.id)
-      return true
     end
-    return false
   end
 
   function obj.playTurns(...)
-    if _checkSector() then
-      return "sectorChanged"
-    end
     local request, extra = _current_sector:playTurns(...)
     if request == 'userTurn' then
       _controlled_actor = extra
+    elseif request == "changeSector" then
+      _checkSector()
     end
     return request, extra
   end

--- a/game/domain/route.lua
+++ b/game/domain/route.lua
@@ -135,11 +135,15 @@ function Route:instance(obj)
     local player_sector = obj.getPlayerActor():getBody():getSector()
     if player_sector ~= _current_sector then
       obj.setCurrentSector(player_sector.id)
+      return true
     end
+    return false
   end
 
   function obj.playTurns(...)
-    _checkSector()
+    if _checkSector() then
+      return "sectorChanged"
+    end
     local request, extra = _current_sector:playTurns(...)
     if request == 'userTurn' then
       _controlled_actor = extra

--- a/game/gamestates/play.lua
+++ b/game/gamestates/play.lua
@@ -33,8 +33,6 @@ local function _playTurns(...)
   elseif request == "userTurn" then
     SWITCHER.push(GS.USER_TURN, _route, _view)
   elseif request == "changeSector" then
-    return _playTurns()
-  elseif request == "sectorChanged" then
     _view.sector:sectorChanged()
     return _playTurns()
   elseif request == "report" then

--- a/game/gamestates/play.lua
+++ b/game/gamestates/play.lua
@@ -34,6 +34,9 @@ local function _playTurns(...)
     SWITCHER.push(GS.USER_TURN, _route, _view)
   elseif request == "changeSector" then
     return _playTurns()
+  elseif request == "sectorChanged" then
+    _view.sector:sectorChanged()
+    return _playTurns()
   elseif request == "report" then
     _view.sector:startVFX(extra)
     SWITCHER.push(GS.ANIMATION, _view.sector)

--- a/game/view/sector.lua
+++ b/game/view/sector.lua
@@ -37,10 +37,14 @@ local SectorView = Class{
   __includes = { ELEMENT }
 }
 
-local function _moveCamera(target)
+local function _moveCamera(target, force)
   local i, j = target:getPos()
   local tx, ty = (j-0.5)*_TILE_W, (i-0.5)*_TILE_H
-  CAM:lockPosition(tx, ty)
+  if force then
+    CAM:lookAt(tx, ty)
+  else
+    CAM:lockPosition(tx, ty)
+  end
 end
 
 
@@ -69,6 +73,7 @@ function SectorView:init(route)
   self.route = route
   self.body_sprites = {}
   self.sector = false
+  self.sector_changed = true
 
   _font = _font or FONT.get("Text", 16)
 
@@ -141,13 +146,18 @@ function SectorView:setBodySprite(body, draw)
   self.body_sprites[body:getId()] = draw
 end
 
+function SectorView:sectorChanged()
+  self.sector_changed = true
+end
+
 function SectorView:draw()
   local g = love.graphics
   local sector = self.route.getCurrentSector()
   self:initSector(sector)
   if not self.sector then return end
   if self.target then
-    _moveCamera(self.target)
+    _moveCamera(self.target, self.sector_changed)
+    self.sector_changed = false
   end
   g.setBackgroundColor(75, 78, 60, 255)
   g.setColor(COLORS.NEUTRAL)


### PR DESCRIPTION
Now camera pans to player instantly when changing sectors.
Please review the sector changing code because it basically adds one run to the `_playTurns()` function in the `play` gamestate.

Related to #543 but it was phrased so as to mention another problem.