### PR TITLE
Add fade ins and outs when loading/quitting gameplay and when changing sectors

### DIFF
--- a/game/domain/route.lua
+++ b/game/domain/route.lua
@@ -131,19 +131,19 @@ function Route:instance(obj)
   function obj.takeExit()
   end
 
-  local function _checkSector()
+  function obj.checkSector()
     local player_sector = obj.getPlayerActor():getBody():getSector()
     if player_sector ~= _current_sector then
       obj.setCurrentSector(player_sector.id)
+      return true
     end
+    return false
   end
 
   function obj.playTurns(...)
     local request, extra = _current_sector:playTurns(...)
     if request == 'userTurn' then
       _controlled_actor = extra
-    elseif request == "changeSector" then
-      _checkSector()
     end
     return request, extra
   end

--- a/game/gamestates/play.lua
+++ b/game/gamestates/play.lua
@@ -36,8 +36,19 @@ local function _playTurns(...)
     SWITCHER.push(GS.USER_TURN, _route, _view, _alert)
     _alert = false
   elseif request == "changeSector" then
-    _view.sector:sectorChanged()
-    return _playTurns()
+    local fade_view = FadeView(FadeView.STATE_UNFADED)
+    fade_view:addElement("GUI")
+    fade_view:fadeOutAndThen(function()
+      local change_sector_ok = _route.checkSector()
+      assert(change_sector_ok, "Sector Change fuck up")
+      _view.sector:sectorChanged()
+      MAIN_TIMER:after(FadeView.FADE_TIME, function()
+        fade_view:fadeInAndThen(function()
+          fade_view:destroy()
+          return _playTurns()
+        end)
+      end)
+    end)
   elseif request == "report" then
     _view.sector:startVFX(extra)
     if extra.type == 'dmg_taken' and

--- a/game/gamestates/play.lua
+++ b/game/gamestates/play.lua
@@ -9,6 +9,7 @@ local SectorView  = require 'view.sector'
 local HandView    = require 'view.hand'
 local ActorView   = require 'view.actor'
 local WidgetView  = require 'view.widgethud'
+local FadeView    = require 'view.fade'
 
 local state = {}
 
@@ -102,12 +103,18 @@ function state:enter(pre, route_data)
   _view.widget = WidgetView(_route)
   _view.widget:addElement("HUD")
 
-  -- start gamestate
-  _playTurns()
-
   -- GUI
   _gui = GUI(_view.sector)
   _gui:addElement("GUI")
+
+  -- start gamestate
+  _playTurns()
+
+  local fade_view = FadeView(FadeView.STATE_FADED)
+  fade_view:addElement("GUI")
+  fade_view:fadeInAndThen(function()
+    fade_view:destroy()
+  end)
 
 end
 

--- a/game/gamestates/play.lua
+++ b/game/gamestates/play.lua
@@ -61,9 +61,16 @@ local function _playTurns(...)
 end
 
 local function _saveAndQuit()
+  local fade_view = FadeView(FadeView.STATE_UNFADED)
   local route_data = _route.saveState()
   PROFILE.saveRoute(route_data)
-  SWITCHER.switch(GS.START_MENU)
+  fade_view:addElement("GUI")
+  fade_view:fadeOutAndThen(function()
+    SWITCHER.switch(GS.START_MENU)
+    fade_view:fadeInAndThen(function()
+      fade_view:destroy()
+    end)
+  end)
 end
 
 --STATE FUNCTIONS--

--- a/game/gamestates/start_menu.lua
+++ b/game/gamestates/start_menu.lua
@@ -6,6 +6,7 @@ local INPUT = require 'input'
 local CONFIGURE_INPUT = require 'input.configure'
 local PROFILE = require 'infra.profile'
 local StartMenuView = require 'view.startmenu'
+local FadeView = require 'view.fade'
 
 local state = {}
 
@@ -44,7 +45,13 @@ function state:resume(from, player_info)
     background = player_info.background
     print(string.format("selected %s %s", species, background))
 
-    SWITCHER.switch(GS.PLAY, route_data)
+    _locked = true
+    local fade_view = FadeView()
+    fade_view:addElement("GUI")
+    fade_view:fadeOutAndThen(function()
+      SWITCHER.switch(GS.PLAY, route_data)
+      fade_view:destroy()
+    end)
   else
     _menu_view:open()
     _menu_context = "START_MENU"
@@ -111,7 +118,12 @@ function state:update(dt)
           if MENU.item(savename) then
             _locked = true
             _menu_view:close(function()
-              SWITCHER.switch(GS.PLAY, PROFILE.loadRoute(route_id))
+              local fade_view = FadeView()
+              fade_view:addElement("GUI")
+              fade_view:fadeOutAndThen(function()
+                SWITCHER.switch(GS.PLAY, PROFILE.loadRoute(route_id))
+                fade_view:destroy()
+              end)
             end)
           end
         end

--- a/game/gamestates/start_menu.lua
+++ b/game/gamestates/start_menu.lua
@@ -16,11 +16,6 @@ local _menu_view
 local _menu_context
 local _locked
 
---LOCAL FUNCTIONS--
-
-local function _title()
-end
-
 --STATE FUNCTIONS--
 
 function state:enter()
@@ -38,18 +33,12 @@ end
 
 function state:resume(from, player_info)
   if player_info then
-    local route_data = PROFILE.newRoute(player_info)
-
-    local species, background
-    species = player_info.species
-    background = player_info.background
-    print(string.format("selected %s %s", species, background))
-
     _locked = true
+    print(("%s %s"):format(player_info.species, player_info.background))
     local fade_view = FadeView()
     fade_view:addElement("GUI")
     fade_view:fadeOutAndThen(function()
-      SWITCHER.switch(GS.PLAY, route_data)
+      SWITCHER.switch(GS.PLAY, PROFILE.newRoute(player_info))
       fade_view:destroy()
     end)
   else
@@ -143,7 +132,6 @@ function state:update(dt)
   end
   MENU.finish()
   _menu_view:setSelection(MENU.getSelection())
-  _title()
 end
 
 function state:draw()

--- a/game/gamestates/start_menu.lua
+++ b/game/gamestates/start_menu.lua
@@ -6,7 +6,6 @@ local INPUT = require 'input'
 local CONFIGURE_INPUT = require 'input.configure'
 local PROFILE = require 'infra.profile'
 local StartMenuView = require 'view.startmenu'
-local FadeView = require 'view.fade'
 
 local state = {}
 
@@ -35,12 +34,7 @@ function state:resume(from, player_info)
   if player_info then
     _locked = true
     print(("%s %s"):format(player_info.species, player_info.background))
-    local fade_view = FadeView()
-    fade_view:addElement("GUI")
-    fade_view:fadeOutAndThen(function()
-      SWITCHER.switch(GS.PLAY, PROFILE.newRoute(player_info))
-      fade_view:destroy()
-    end)
+    SWITCHER.switch(GS.PLAY, PROFILE.newRoute(player_info))
   else
     _menu_view:open()
     _menu_context = "START_MENU"
@@ -107,12 +101,7 @@ function state:update(dt)
           if MENU.item(savename) then
             _locked = true
             _menu_view:close(function()
-              local fade_view = FadeView()
-              fade_view:addElement("GUI")
-              fade_view:fadeOutAndThen(function()
-                SWITCHER.switch(GS.PLAY, PROFILE.loadRoute(route_id))
-                fade_view:destroy()
-              end)
+              SWITCHER.switch(GS.PLAY, PROFILE.loadRoute(route_id))
             end)
           end
         end

--- a/game/view/fade.lua
+++ b/game/view/fade.lua
@@ -5,11 +5,15 @@ local FadeView = Class{
 
 local _FADE_TIME = 0.25
 local _FADE_TWEEN = "FADING_TWEEN"
+local _FADE_CONFLICT_ERR = [=[
+Fade animations conflicting.
+Please wait until one of them is finished]=]
 
 --[[ PUBLIC METHODS ]]--
 
 FadeView.STATE_FADED = 1
 FadeView.STATE_UNFADED = 0
+FadeView.FADE_TIME = _FADE_TIME
 
 function FadeView:init(fade_state)
   ELEMENT.init(self)
@@ -20,26 +24,26 @@ function FadeView:init(fade_state)
 end
 
 function FadeView:fadeOutAndThen(do_a_thing)
-  assert(not self.fading_out and not self.fading_in)
+  assert(not self.fading_out and not self.fading_in, _FADE_CONFLICT_ERR)
   self.fading_out = true
   self:removeTimer(_FADE_TWEEN, MAIN_TIMER)
   self:addTimer(_FADE_TWEEN, MAIN_TIMER, "tween", _FADE_TIME,
                 self, { alpha = 1 }, "linear",
                 function()
-                  do_a_thing()
                   self.fading_out = false
+                  do_a_thing()
                 end)
 end
 
 function FadeView:fadeInAndThen(do_a_thing)
-  assert(not self.fading_out and not self.fading_in)
+  assert(not self.fading_out and not self.fading_in, _FADE_CONFLICT_ERR)
   self.fading_in = true
   self:removeTimer(_FADE_TWEEN, MAIN_TIMER)
   self:addTimer(_FADE_TWEEN, MAIN_TIMER, "tween", _FADE_TIME,
                 self, { alpha = 0 }, "linear",
                 function()
-                  do_a_thing()
                   self.fading_in = false
+                  do_a_thing()
                 end)
 end
 

--- a/game/view/fade.lua
+++ b/game/view/fade.lua
@@ -1,0 +1,53 @@
+
+local FadeView = Class{
+  __includes = { ELEMENT }
+}
+
+local _FADE_TIME = 0.25
+local _FADE_TWEEN = "FADING_TWEEN"
+
+--[[ PUBLIC METHODS ]]--
+
+FadeView.STATE_FADED = 1
+FadeView.STATE_UNFADED = 0
+
+function FadeView:init(fade_state)
+  ELEMENT.init(self)
+  self.fading_in = false
+  self.fading_out = false
+  self.exception = true
+  self.alpha = fade_state or FadeView.STATE_UNFADED
+end
+
+function FadeView:fadeOutAndThen(do_a_thing)
+  assert(not self.fading_out and not self.fading_in)
+  self.fading_out = true
+  self:removeTimer(_FADE_TWEEN, MAIN_TIMER)
+  self:addTimer(_FADE_TWEEN, MAIN_TIMER, "tween", _FADE_TIME,
+                self, { alpha = 1 }, "linear",
+                function()
+                  do_a_thing()
+                  self.fading_out = false
+                end)
+end
+
+function FadeView:fadeInAndThen(do_a_thing)
+  assert(not self.fading_out and not self.fading_in)
+  self.fading_in = true
+  self:removeTimer(_FADE_TWEEN, MAIN_TIMER)
+  self:addTimer(_FADE_TWEEN, MAIN_TIMER, "tween", _FADE_TIME,
+                self, { alpha = 0 }, "linear",
+                function()
+                  do_a_thing()
+                  self.fading_in = false
+                end)
+end
+
+function FadeView:draw()
+  local g = love.graphics
+  g.setColor(0, 0, 0, self.alpha * 0xff)
+  g.rectangle("fill", 0, 0, g.getDimensions())
+end
+
+return FadeView
+

--- a/game/view/sector.lua
+++ b/game/view/sector.lua
@@ -73,7 +73,7 @@ function SectorView:init(route)
   self.route = route
   self.body_sprites = {}
   self.sector = false
-  self.sector_changed = true
+  self.sector_changed = false
 
   _font = _font or FONT.get("Text", 16)
 

--- a/game/view/widgethud.lua
+++ b/game/view/widgethud.lua
@@ -101,10 +101,14 @@ end
 
 function view:draw()
   local g = love.graphics
+
   local actor = self:isValidActor()
+  if not actor then return end
+
   local widget_list = self:getWidgetList(actor)
+  if not widget_list then return end
+
   local enter = self.enter
-  if not actor or not widget_list then return end
 
   if enter > 0 then
     local w = WIDGETVIEW.getWidth()


### PR DESCRIPTION
Pretty simple, just a new view that fades things.
Makes our eyes bleed less.

I noticed that when we quit the `play` gamestate, there is a single frame in which there is no view in the draw tables. I thought it to be a little weird that it only happens when switching from `play` to `start_menu` but not the other way around, but I didn't want to deal with that gamestate switching BS, so I just made the fade view deal with it for me – it is simply not deleted until it fades back in again after quitting `play`. So there.

Also the camera "pans out" when you change sectors, but is that a bad thing?