### PR TITLE
Nerf speed upgrades

### DIFF
--- a/game/database/domains/cardset/upgrades.json
+++ b/game/database/domains/cardset/upgrades.json
@@ -1,3 +1,4 @@
 {
+  "parent":false,
   "name":"Upgrades"
 }

--- a/game/database/domains/cardset/upgrades_ani.json
+++ b/game/database/domains/cardset/upgrades_ani.json
@@ -1,4 +1,4 @@
 {
-  "parent":"upgrades",
+  "parent":"upgrades_common",
   "name":"Anima Upgrades"
 }

--- a/game/database/domains/cardset/upgrades_arc.json
+++ b/game/database/domains/cardset/upgrades_arc.json
@@ -1,4 +1,4 @@
 {
   "name":"Arcana Upgrades",
-  "parent":"upgrades"
+  "parent":"upgrades_common"
 }

--- a/game/database/domains/cardset/upgrades_common.json
+++ b/game/database/domains/cardset/upgrades_common.json
@@ -1,0 +1,4 @@
+{
+  "name":"Upgrades Common",
+  "parent":false
+}

--- a/game/database/domains/cardset/upgrades_cor.json
+++ b/game/database/domains/cardset/upgrades_cor.json
@@ -1,4 +1,4 @@
 {
   "name":"Corporis Upgrades",
-  "parent":"upgrades"
+  "parent":"upgrades_common"
 }

--- a/game/database/domains/cardset/upgrades_def.json
+++ b/game/database/domains/cardset/upgrades_def.json
@@ -1,4 +1,4 @@
 {
   "name":"Defense Upgrades",
-  "parent":"upgrades"
+  "parent":"upgrades_common"
 }

--- a/game/database/domains/cardset/upgrades_spd.json
+++ b/game/database/domains/cardset/upgrades_spd.json
@@ -1,4 +1,4 @@
 {
   "name":"Speed Upgrades",
-  "parent":"upgrades"
+  "parent":"upgrades_special"
 }

--- a/game/database/domains/cardset/upgrades_special.json
+++ b/game/database/domains/cardset/upgrades_special.json
@@ -1,0 +1,4 @@
+{
+  "parent":"upgrades",
+  "name":"Upgrades Special"
+}

--- a/game/database/domains/cardset/upgrades_vit.json
+++ b/game/database/domains/cardset/upgrades_vit.json
@@ -1,4 +1,4 @@
 {
   "name":"Vitality Upgrades",
-  "parent":"upgrades"
+  "parent":"upgrades_common"
 }

--- a/game/database/domains/collection/anything.json
+++ b/game/database/domains/collection/anything.json
@@ -1,18 +1,18 @@
 {
-  "cards":[{
-      "drop":80,
-      "set":"upgrades"
-    },{
-      "set":"upgrades",
-      "drop":60
-    },{
-      "drop":40,
-      "set":"upgrades"
-    },{
-      "drop":80,
-      "set":"consumables"
-    }],
   "name":"Anything",
   "image":"card-rage",
-  "description":"Drops literally anything."
+  "cards":[{
+      "set":"upgrades_common",
+      "drop":80
+    },{
+      "drop":60,
+      "set":"upgrades_common"
+    },{
+      "set":"upgrades_common",
+      "drop":40
+    },{
+      "set":"consumables",
+      "drop":80
+    }],
+  "description":false
 }

--- a/game/debug/view/name_input.lua
+++ b/game/debug/view/name_input.lua
@@ -7,7 +7,7 @@ return function(title, validator)
 
   return "Name for " .. title, 1, function(gui)
     local changed
-    changed, name = IMGUI.InputText("", name, 64)
+    name, changed = IMGUI.InputText("", name, 64)
     if (IMGUI.Button("Confirm") or IMGUI.IsKeyPressed(12))
         and name ~= "" then
       validator(name)

--- a/game/domain/sector.lua
+++ b/game/domain/sector.lua
@@ -190,7 +190,7 @@ function Sector:makeEncounters(encounters, register)
     if upgradexp > 0 then
       local unit, total = 0, 0
       local aptitudes = {}
-      for _,attr in ipairs(DEFS.ATTRIBUTES) do
+      for _,attr in ipairs(DEFS.PRIMARY_ATTRIBUTES) do
         aptitudes[attr] = actor:getSpec(attr:lower()) + 4 -- min of 0
         total = total + aptitudes[attr]
       end
@@ -201,10 +201,10 @@ function Sector:makeEncounters(encounters, register)
       unit = upgradexp / total
       for attr,priority in pairs(aptitudes) do
         local award = math.floor(unit * priority)
-        if DEFS.ATTRIBUTES[attr] then
+        if DEFS.PRIMARY_ATTRIBUTES[attr] then
           actor:upgradeAttr(attr, award)
         elseif DEFS.BODY_ATTRIBUTES[attr] then
-          body:upgradeAttr(attr, award)
+          body:upgradeAttr(attr, math.floor(award / 2))
         end
       end
     end


### PR DESCRIPTION
Speed upgrades are no longer a common thing, not even among monsters. Now monsters do not get speed upgrades, and neither does the player. I mean, there is still a small tiny chance of getting a speed upgrade card, but it's much much rarer now.

Also fixed a bug in the devmode that crashed the game when creating new entries.