### PR TITLE
Enhance monster behavior

### DIFF
--- a/game/database/domains/card/teleport.json
+++ b/game/database/domains/card/teleport.json
@@ -1,13 +1,24 @@
 {
-  "pp":4,
-  "desc":"Teleport self to target position.\n\n\"Transporting all the molecules in your body has never been so easy! But I wonder if your original self dies everytime you do that... well who cares.\"",
+  "attr":"ARC",
+  "icon":"card-teleport",
+  "one_time":false,
   "art":{
-    "cost":20,
     "art_ability":{
+      "effects":[{
+          "vfx-spd":1,
+          "vfx":false,
+          "type":"effect",
+          "body":"=Body",
+          "name":"move_to",
+          "pos":"=target_pos"
+        }],
       "inputs":[{
-          "type":"input",
-          "output":"target_pos",
           "empty-tile":true,
+          "output":"target_pos",
+          "aoe-hint":0,
+          "dif-fact":false,
+          "type":"input",
+          "non-wall":true,
           "name":"choose_target",
           "max-range":7
         },{
@@ -16,24 +27,16 @@
           "output":"Actor"
         },{
           "type":"operator",
-          "actor":"=Actor",
+          "output":"Body",
           "name":"get_actor_body",
-          "output":"Body"
-        }],
-      "effects":[{
-          "body":"=Body",
-          "pos":"=target_pos",
-          "vfx-spd":1,
-          "vfx":false,
-          "name":"move_to",
-          "type":"effect"
+          "actor":"=Actor"
         }]
-    }
+    },
+    "cost":20
   },
-  "one_time":false,
-  "icon":"card-teleport",
-  "set":false,
+  "desc":false,
   "type-description":"",
-  "attr":"ARC",
-  "name":"Teleport"
+  "pp":4,
+  "name":"Teleport",
+  "set":false
 }

--- a/game/debug/view/actor_inspector.lua
+++ b/game/debug/view/actor_inspector.lua
@@ -11,7 +11,7 @@ return function (actor)
     IMGUI.Text(("Title: %s"):format(actor:getTitle()))
     IMGUI.Separator()
     IMGUI.PushItemWidth(100)
-    local changed, newhp = IMGUI.SliderInt("Hit Points", hp, 1,
+    local newhp, changed = IMGUI.SliderInt("Hit Points", hp, 1,
                                            actor:getBody():getMaxHP())
     IMGUI.PopItemWidth()
     if changed then

--- a/game/debug/view/body_inspector.lua
+++ b/game/debug/view/body_inspector.lua
@@ -10,7 +10,7 @@ return function (body)
     IMGUI.Text(("Species: %s"):format(body:getSpec('name')))
     IMGUI.Separator()
     IMGUI.PushItemWidth(100)
-    local changed, newhp = IMGUI.SliderInt("Hit Points", hp, 1,
+    local newhp, changed = IMGUI.SliderInt("Hit Points", hp, 1,
                                            body:getMaxHP())
     IMGUI.PopItemWidth()
     if changed then

--- a/game/domain/actor.lua
+++ b/game/domain/actor.lua
@@ -46,7 +46,6 @@ function Actor:init(spec_name)
   self.exp = 0
   self.playpoints = DEFS.MAX_PP
 
-  self.seen_bodies = {}
   self.fov = {}
   self.fov_range = 4
 
@@ -366,31 +365,23 @@ end
 
 -- Visibility Methods --
 
-function Actor:hasVisibleBodies()
-  return not not next(self.seen_bodies)
-end
-
-function Actor:eachSeenBody()
-  return pairs(self.seen_bodies)
-end
-
-function Actor:updateSeenBodies()
-  local seen = self.seen_bodies
+function Actor:getVisibleBodies()
+  local seen = {}
   local sector = self:getBody():getSector()
   local w, h = sector:getDimensions()
-  for body_id in pairs(self.seen_bodies) do
-    seen[body_id] = nil
-  end
-  for i = 1, w do
-    for j = 1, h do
+
+  for i = 1, h do
+    for j = 1, w do
       local body = sector:getBodyAt(i, j)
-      local fov = self.fov[sector:getId()]
-      local visibility = fov and fov[i] and fov[i][j]
-      if body and body ~= self:getBody() and visibility and visibility ~= 0 then
+      local fov = self:getFov(sector)
+      local visible = fov and fov[i] and fov[i][j]
+      if body and body ~= self:getBody() and visible and visible ~= 0 then
         seen[body:getId()] = true
       end
     end
   end
+
+  return seen
 end
 
 function Actor:purgeFov(sector)
@@ -405,8 +396,7 @@ function Actor:resetFov(sector)
 end
 
 function Actor:updateFov(sector)
-  Visibility.updateFov(self,sector)
-  self:updateSeenBodies()
+  Visibility.updateFov(self, sector)
 end
 
 function Actor:getFov(sector)

--- a/game/domain/actor.lua
+++ b/game/domain/actor.lua
@@ -378,9 +378,7 @@ function Actor:updateSeenBodies()
   local seen = self.seen_bodies
   local sector = self:getBody():getSector()
   local w, h = sector:getDimensions()
-  printf("##Actor: %s:%s", self:getSpecName(), self:getId())
   for body_id in pairs(self.seen_bodies) do
-    printf("  > deleting body: %s", body_id)
     seen[body_id] = nil
   end
   for i = 1, w do
@@ -389,7 +387,6 @@ function Actor:updateSeenBodies()
       local fov = self.fov[sector:getId()]
       local visibility = fov and fov[i] and fov[i][j]
       if body and body ~= self:getBody() and visibility and visibility ~= 0 then
-        printf("  > %s", body:getId())
         seen[body:getId()] = true
       end
     end

--- a/game/domain/behaviors/aggro.lua
+++ b/game/domain/behaviors/aggro.lua
@@ -1,6 +1,7 @@
 
 local TILE       = require 'common.tile'
 local Action     = require 'domain.action'
+local MANEUVERS  = require 'lux.pack' 'domain.maneuver'
 local ACTIONDEFS = require 'domain.definitions.action'
 local FindPath   = require 'domain.behaviors.helpers.findpath'
 local RandomWalk = require 'domain.behaviors.helpers.random'
@@ -26,17 +27,17 @@ return function (actor)
     end
   end
 
-  if not target then
-    -- i can't see anybody of opposing faction!
-    return RandomWalk.execute(actor)
-  elseif dist == 1 then
-    -- attack if close!
-    return ACTIONDEFS.USE_SIGNATURE, { pos = {target:getPos()} }
-  elseif dist <= 8 then
-    -- chase if far away!
-    local pos = FindPath.getNextStep({i,j}, {target:getPos()}, sector)
-    if pos then
-      return ACTIONDEFS.MOVE, { pos = pos }
+  if target then
+    local inputs = { pos = { target:getPos() } }
+    if MANEUVERS[ACTIONDEFS.USE_SIGNATURE].validate(actor, inputs) then
+      -- attack if close!
+      return ACTIONDEFS.USE_SIGNATURE, inputs
+    else
+      -- chase if far away!
+      inputs.pos = FindPath.getNextStep({i, j}, inputs.pos, sector)
+      if inputs.pos and MANEUVERS[ACTIONDEFS.MOVE].validate(actor, inputs) then
+        return ACTIONDEFS.MOVE, inputs
+      end
     end
   end
 

--- a/game/domain/behaviors/aggro.lua
+++ b/game/domain/behaviors/aggro.lua
@@ -10,6 +10,7 @@ return function (actor)
   local sector = actor:getBody():getSector()
   local i, j = actor:getPos()
 
+  -- i can't see anybody!
   if not actor:hasVisibleBodies() then return RandomWalk.execute(actor) end
 
   -- create list of opponents
@@ -26,7 +27,7 @@ return function (actor)
   end
 
   if not target then
-    -- i can't see anybody!
+    -- i can't see anybody of opposing faction!
     return RandomWalk.execute(actor)
   elseif dist == 1 then
     -- attack if close!

--- a/game/domain/behaviors/aggro.lua
+++ b/game/domain/behaviors/aggro.lua
@@ -11,12 +11,12 @@ return function (actor)
   local i, j = actor:getPos()
 
   -- i can't see anybody!
-  if not actor:hasVisibleBodies() then return RandomWalk.execute(actor) end
+  local visible_bodies = actor:getVisibleBodies()
 
   -- create list of opponents
-  for body_id,seen in actor:eachSeenBody() do
+  for body_id in pairs(visible_bodies) do
     local opponent = Util.findId(body_id)
-    if opponent:getFaction() ~= actor:getBody():getFaction() then
+    if opponent and opponent:getFaction() ~= actor:getBody():getFaction() then
       local k, l = opponent:getPos()
       local d = TILE.dist(i, j, k, l)
       if not target or not dist or d < dist then

--- a/game/domain/behaviors/aggro.lua
+++ b/game/domain/behaviors/aggro.lua
@@ -14,9 +14,8 @@ return function (actor)
   -- create list of opponents
   for body_id,seen in actor:eachSeenBody() do
     local opponent = Util.findId(body_id)
-    print(opponent:getSpecName())
-    if opponent:getFaction() ~= self:getBody():getFaction() then
-      local k, l = identityp(opponent:getPos())
+    if opponent:getFaction() ~= actor:getBody():getFaction() then
+      local k, l = opponent:getPos()
       local d = TILE.dist(i, j, k, l)
       if not target or not dist or d < dist then
         target = opponent
@@ -25,7 +24,10 @@ return function (actor)
     end
   end
 
-  if dist == 1 then
+  if not dist then
+    -- there are not valid targets!
+    return ACTIONDEFS.IDLE, {}
+  elseif dist == 1 then
     -- attack if close!
     return ACTIONDEFS.USE_SIGNATURE, { pos = {target:getPos()} }
   elseif dist <= 8 then
@@ -36,6 +38,7 @@ return function (actor)
     end
   end
 
+  -- there are valid targets, but i can't reach them
   return ACTIONDEFS.IDLE, {}
 end
 

--- a/game/domain/behaviors/aggro.lua
+++ b/game/domain/behaviors/aggro.lua
@@ -9,10 +9,14 @@ return function (actor)
   local sector = actor:getBody():getSector()
   local i, j = actor:getPos()
 
+  if not actor:hasVisibleBodies() then return ACTIONDEFS.IDLE end
+
   -- create list of opponents
-  for _,opponent in sector:iterateActors() do
-    if opponent:isPlayer() then
-      local k, l = opponent:getPos()
+  for body_id,seen in actor:eachSeenBody() do
+    local opponent = Util.findId(body_id)
+    print(opponent:getSpecName())
+    if opponent:getFaction() ~= self:getBody():getFaction() then
+      local k, l = identityp(opponent:getPos())
       local d = TILE.dist(i, j, k, l)
       if not target or not dist or d < dist then
         target = opponent

--- a/game/domain/behaviors/aggro.lua
+++ b/game/domain/behaviors/aggro.lua
@@ -1,87 +1,8 @@
 
-local DIR = require 'domain.definitions.dir'
+local TILE       = require 'common.tile'
+local Action     = require 'domain.action'
 local ACTIONDEFS = require 'domain.definitions.action'
-local Action = require 'domain.action'
-local TILE = require 'common.tile'
-local Heap = require 'common.heap'
-
-local abs = math.abs
-local VISION = 8
-local DEDICATION = VISION * 4
-local LIMIT = DEDICATION * 2
-local WIDTH = 1
-
-local function _hash(pos)
-  if not pos then return "none" end
-  local i, j = unpack(pos)
-  return i*WIDTH + j
-end
-
-local function _heuristic(pos1, pos2)
-  local i1, j1 = unpack(pos1)
-  local i2, j2 = unpack(pos2)
-  return TILE.dist(i1, j1, i2, j2)
-end
-
-local function _findPath(start, goal, sector)
-  local frontier = Heap:new()
-  local came_from = {}
-  local cost_so_far = {}
-  local path = {}
-  local found = false
-  local iterations = 0
-  WIDTH = sector:getDimensions()
-
-  frontier:add(start, 0)
-  came_from[_hash(start)] = true
-  cost_so_far[_hash(start)] = 0
-
-  while not frontier:isEmpty() do
-    iterations = iterations + 1
-    local current, rank = frontier:getNext()
-
-    -- if you found your goal, quit loop
-    if _heuristic(goal, current) == 1 then
-      found = true
-      goal = current
-      break
-    end
-
-    if iterations >= LIMIT then break end
-
-    -- look at neighbors
-    for _,dir in ipairs(DIR) do
-      local di, dj = unpack(DIR[dir])
-      local i, j = unpack(current)
-      local ti, tj = unpack(goal)
-      local next_pos = { i+di, j+dj }
-      local distance = _heuristic(goal, next_pos)
-
-      if sector:isValid(unpack(next_pos)) and distance < DEDICATION then
-        local new_cost = cost_so_far[_hash(current)] + 1
-
-        -- is it a valid and not yet checked neighbor?
-        if not cost_so_far[_hash(next_pos)]
-          or new_cost < cost_so_far[_hash(next_pos)] then
-          local new_rank = new_cost + 2 * distance
-          cost_so_far[_hash(next_pos)] = new_cost
-          came_from[_hash(next_pos)] = current
-          frontier:add(next_pos, new_rank)
-        end
-      end
-    end
-  end
-
-  local current = goal
-  if found then
-    while _hash(start) ~= _hash(current) do
-      table.insert(path, current)
-      current = came_from[_hash(current)]
-    end
-    return path[#path]
-  end
-  return false
-end
+local FindPath   = require 'domain.behaviors.helpers.findpath'
 
 return function (actor)
   local target, dist
@@ -92,7 +13,7 @@ return function (actor)
   for _,opponent in sector:iterateActors() do
     if opponent:isPlayer() then
       local k, l = opponent:getPos()
-      local d = _heuristic({i, j}, {k, l})
+      local d = TILE.dist(i, j, k, l)
       if not target or not dist or d < dist then
         target = opponent
         dist = d
@@ -103,9 +24,9 @@ return function (actor)
   if dist == 1 then
     -- attack if close!
     return ACTIONDEFS.USE_SIGNATURE, { pos = {target:getPos()} }
-  elseif dist <= VISION then
+  elseif dist <= 8 then
     -- chase if far away!
-    local pos = _findPath({i,j}, {target:getPos()}, sector)
+    local pos = FindPath.getNextStep({i,j}, {target:getPos()}, sector)
     if pos then
       return ACTIONDEFS.MOVE, { pos = pos }
     end

--- a/game/domain/behaviors/aggro.lua
+++ b/game/domain/behaviors/aggro.lua
@@ -3,13 +3,14 @@ local TILE       = require 'common.tile'
 local Action     = require 'domain.action'
 local ACTIONDEFS = require 'domain.definitions.action'
 local FindPath   = require 'domain.behaviors.helpers.findpath'
+local RandomWalk = require 'domain.behaviors.helpers.random'
 
 return function (actor)
   local target, dist
   local sector = actor:getBody():getSector()
   local i, j = actor:getPos()
 
-  if not actor:hasVisibleBodies() then return ACTIONDEFS.IDLE end
+  if not actor:hasVisibleBodies() then return RandomWalk.execute(actor) end
 
   -- create list of opponents
   for body_id,seen in actor:eachSeenBody() do
@@ -24,9 +25,9 @@ return function (actor)
     end
   end
 
-  if not dist then
-    -- there are not valid targets!
-    return ACTIONDEFS.IDLE, {}
+  if not target then
+    -- i can't see anybody!
+    return RandomWalk.execute(actor)
   elseif dist == 1 then
     -- attack if close!
     return ACTIONDEFS.USE_SIGNATURE, { pos = {target:getPos()} }
@@ -39,6 +40,6 @@ return function (actor)
   end
 
   -- there are valid targets, but i can't reach them
-  return ACTIONDEFS.IDLE, {}
+  return RandomWalk.execute(actor)
 end
 

--- a/game/domain/behaviors/helpers/findpath.lua
+++ b/game/domain/behaviors/helpers/findpath.lua
@@ -1,0 +1,93 @@
+
+local DIR  = require 'domain.definitions.dir'
+local Heap = require 'common.heap'
+local TILE = require 'common.tile'
+
+
+-- CONSTANTS --
+
+local _DEDICATION = 32
+local _LIMIT = 64
+
+
+-- LOCAL FUNCTIONS --
+
+local function _hash(pos, width)
+  if not pos then return "none" end
+  local i, j = unpack(pos)
+  return i * width + j
+end
+
+local function _heuristic(pos1, pos2)
+  local i1, j1 = unpack(pos1)
+  local i2, j2 = unpack(pos2)
+  return TILE.dist(i1, j1, i2, j2)
+end
+
+
+-- MODULE METHODS --
+
+local FindPath = {}
+
+function FindPath.getNextStep(start, goal, sector)
+  local frontier = Heap:new()
+  local came_from = {}
+  local cost_so_far = {}
+  local path = {}
+  local found = false
+  local iterations = 0
+  local swidth = sector:getDimensions()
+
+  frontier:add(start, 0)
+  came_from[_hash(start, swidth)] = true
+  cost_so_far[_hash(start, swidth)] = 0
+
+  while not frontier:isEmpty() do
+    iterations = iterations + 1
+    local current, rank = frontier:getNext()
+
+    -- if you found your goal, quit loop
+    if _heuristic(goal, current) == 1 then
+      found = true
+      goal = current
+      break
+    end
+
+    if iterations >= _LIMIT then break end
+
+    -- look at neighbors
+    for _,dir in ipairs(DIR) do
+      local di, dj = unpack(DIR[dir])
+      local i, j = unpack(current)
+      local ti, tj = unpack(goal)
+      local next_pos = { i+di, j+dj }
+      local distance = _heuristic(goal, next_pos)
+
+      if sector:isValid(unpack(next_pos)) and distance < _DEDICATION then
+        local new_cost = cost_so_far[_hash(current, swidth)] + 1
+
+        -- is it a valid and not yet checked neighbor?
+        if not cost_so_far[_hash(next_pos, swidth)]
+          or new_cost < cost_so_far[_hash(next_pos, swidth)] then
+          local new_rank = new_cost + 2 * distance
+          cost_so_far[_hash(next_pos, swidth)] = new_cost
+          came_from[_hash(next_pos, swidth)] = current
+          frontier:add(next_pos, new_rank)
+        end
+      end
+    end
+  end
+
+  local current = goal
+  if found then
+    while _hash(start, swidth) ~= _hash(current, swidth) do
+      table.insert(path, current)
+      current = came_from[_hash(current, swidth)]
+    end
+    return path[#path]
+  end
+  return false
+end
+
+return FindPath
+

--- a/game/domain/behaviors/helpers/random.lua
+++ b/game/domain/behaviors/helpers/random.lua
@@ -1,0 +1,26 @@
+
+local MANEUVERS  = require 'lux.pack' 'domain.maneuver'
+local ACTIONDEFS = require 'domain.definitions.action'
+local RANDOM     = require 'common.random'
+local DIR        = require 'domain.definitions.dir'
+
+local _IDLE = 0
+
+local RandomWalk = {}
+
+function RandomWalk.execute(actor)
+  local i, j = actor:getPos()
+  local input = {}
+  repeat
+    local idx = RANDOM.generate(0, 8)
+    if idx == 0 then
+      return ACTIONDEFS.IDLE, {}
+    end
+    local di, dj = unpack(DIR[DIR[idx]])
+    input.pos = {i+di, j+dj}
+  until MANEUVERS[ACTIONDEFS.MOVE].validate(actor, input)
+  return ACTIONDEFS.MOVE, input
+end
+
+return RandomWalk
+

--- a/game/view/sector.lua
+++ b/game/view/sector.lua
@@ -93,6 +93,9 @@ end
 
 function SectorView:lookAt(target)
   self.target = target
+  if target and target.fov then
+    self:updateFov(target)
+  end
 end
 
 function SectorView:updateVFX(dt)

--- a/game/view/sector/tilemap.lua
+++ b/game/view/sector/tilemap.lua
@@ -70,8 +70,6 @@ function TileMap.drawFloor(g, fov)
         else
           _tile_batch:setColor(COLORS.NEUTRAL)
         end
-      else
-        error(string.format("No FOV in tile [%d, %d]", ti, tj))
       end
       _tile_batch:add(_tile_quads[tile_type], x, y,
                   0, 1, 1, unpack(_tile_offset[tile.type]))


### PR DESCRIPTION
The 'aggro' behavior now is much much cleaner.

I have taken the liberty of doing some extra things:
+ Fix a bug in teleport card that allows you to teleport to the wall and crash the game
+ Fix a bug on devmode that would crash the game when inspecting actors/bodies
+ Now inspecting an actor shows you their FOV.
+ A-star algorythm is now in a separate file, thus closes #335 
+ Monsters chase anything that isn't of their own faction – needs expanding to tell which factions are neutral
+ Monsters take into consideration if their current range is to hit you. Imps and Eyes now attack from 2 tiles away! Be careful.
+ Blindness now works. If a monster doesn't see you, it walks aimlessly.

Things I have noticed:
+ The turns take longer if there are more monsters in the sector. Are we animating non-visible monsters?
+ Sectors are now super small because of the bigger margins from #628. Sometimes advancing is impossible because of this. I fixed it on #638 
+ Sometimes inspecting a monster will show it really off the grid??? I blame sectorview.