### PR TITLE
Fix start menu locking glitch and Add slight black time before starting route

### DIFF
--- a/game/gamestates/play.lua
+++ b/game/gamestates/play.lua
@@ -128,8 +128,10 @@ function state:enter(pre, route_data)
 
   local fade_view = FadeView(FadeView.STATE_FADED)
   fade_view:addElement("GUI")
-  fade_view:fadeInAndThen(function()
-    fade_view:destroy()
+  MAIN_TIMER:after(FadeView.FADE_TIME, function()
+    fade_view:fadeInAndThen(function()
+      fade_view:destroy()
+    end)
   end)
 
 end

--- a/game/gamestates/start_menu.lua
+++ b/game/gamestates/start_menu.lua
@@ -38,6 +38,7 @@ function state:enter()
   _menu_view = StartMenuView()
   _menu_view:addElement("HUD")
 
+  _locked = true
   local _fade_view = FadeView(FadeView.STATE_FADED)
   _fade_view:addElement("GUI")
   _fade_view:fadeInAndThen(function()
@@ -59,6 +60,7 @@ function state:resume(from, player_info)
   else
     _menu_context = "START_MENU"
     _menu_view.invisible = false
+    _locked = true
     local _fade_view = FadeView(FadeView.STATE_FADED)
     _fade_view:addElement("GUI")
     _fade_view:fadeInAndThen(function()


### PR DESCRIPTION
When you start the game and mash confirm, the game soft-locks in the character select screen because you loaded a shitton of gamestates on top of each other.

The fix was to correctly set the locked flag in the startmenu gamestate.

Also added a small black screen time when starting route. I noticed sometimes it loaded too fast and it rendered stuff all over the place. A small black screen time window smooths it out.