### PR TITLE
Enhance longwalk

### DIFF
--- a/game/domain/actor.lua
+++ b/game/domain/actor.lua
@@ -408,6 +408,19 @@ function Actor:canSee(target)
   return visible and visible > 0
 end
 
+function Actor:getHostileBodies()
+  local visible_bodies = self:getVisibleBodies()
+  local hostile_bodies = {}
+  local actor_body_faction = self:getBody():getFaction()
+  for body_id in pairs(visible_bodies) do
+    local body = Util.findId(body_id)
+    if body:getFaction() ~= actor_body_faction then
+      table.insert(hostile_bodies, body)
+    end
+  end
+  return hostile_bodies
+end
+
 function Actor:purgeFov(sector)
   local fov = self:getFov(sector)
   if not fov then

--- a/game/gamestates/animation.lua
+++ b/game/gamestates/animation.lua
@@ -1,7 +1,4 @@
 
-local DB           = require 'database'
-local DIR          = require 'domain.definitions.dir'
-local DIRECTIONALS = require 'infra.dir'
 local INPUT        = require 'input'
 
 local state = {}
@@ -36,19 +33,9 @@ function state:update(dt)
 
   MAIN_TIMER:update(dt)
 
-  if not _alert then
-    for _,dir in ipairs(DIR) do
-      if DIRECTIONALS.wasDirectionTriggered(dir) then
-        _alert = true
-      end
-    end
-    for input in pairs(DB.loadSetting('controls').digital) do
-      if INPUT.wasActionPressed(input) then
-        _alert = true
-      end
-    end
+  if INPUT.wasAnyPressed(0.5) then
+    _alert = true
   end
-
 
   if not _sector_view:hasPendingVFX() then
     SWITCHER.pop(_alert)

--- a/game/gamestates/animation.lua
+++ b/game/gamestates/animation.lua
@@ -1,10 +1,15 @@
 
+local DB           = require 'database'
+local DIR          = require 'domain.definitions.dir'
+local DIRECTIONALS = require 'infra.dir'
+local INPUT        = require 'input'
 
 local state = {}
 
 --[[ LOCAL VARIABLES ]]--
 
 local _sector_view
+local _alert
 
 --[[ LOCAL FUNCTIONS ]]--
 
@@ -17,6 +22,7 @@ end
 function state:enter(_, sector_view, animation)
 
   _sector_view = sector_view
+  _alert = false
 
 end
 
@@ -30,8 +36,22 @@ function state:update(dt)
 
   MAIN_TIMER:update(dt)
 
+  if not _alert then
+    for _,dir in ipairs(DIR) do
+      if DIRECTIONALS.wasDirectionTriggered(dir) then
+        _alert = true
+      end
+    end
+    for input in pairs(DB.loadSetting('controls').digital) do
+      if INPUT.wasActionPressed(input) then
+        _alert = true
+      end
+    end
+  end
+
+
   if not _sector_view:hasPendingVFX() then
-    SWITCHER.pop()
+    SWITCHER.pop(_alert)
   else
     _sector_view:updateVFX(dt)
   end

--- a/game/gamestates/play.lua
+++ b/game/gamestates/play.lua
@@ -1,6 +1,7 @@
 
 --MODULE FOR THE GAMESTATE: GAME--
 
+local INPUT       = require 'input'
 local GUI         = require 'debug.gui'
 local PROFILE     = require 'infra.profile'
 local PLAYSFX     = require 'helpers.playsfx'
@@ -173,6 +174,10 @@ end
 function state:update(dt)
 
   if not DEBUG then
+    if INPUT.wasAnyPressed(0.5) then
+      _alert = true
+    end
+
     MAIN_TIMER:update(dt)
     if _next_action then
       _playTurns(unpack(_next_action))

--- a/game/gamestates/play.lua
+++ b/game/gamestates/play.lua
@@ -190,6 +190,7 @@ function state:resume(state, args)
     if args == "SAVE_AND_QUIT" then return _activity:saveAndQuit() end
     _next_action = args.next_action
   elseif state == GS.ANIMATION then
+    _alert = _alert or args
     _playTurns()
   end
 

--- a/game/gamestates/user_turn.lua
+++ b/game/gamestates/user_turn.lua
@@ -137,9 +137,12 @@ function state:update(dt)
     end
   else
     local action_request
+    local faction = _route.getControlledActor():getBody():getFaction()
+    local hostile_bodies = _route.getControlledActor():getHostileBodies()
     for _,dir in ipairs(DIR) do
       if DIRECTIONALS.wasDirectionTriggered(dir) then
-        if not _long_walk and INPUT.isActionDown('MODIFIER') then
+        if not _long_walk and #hostile_bodies == 0
+                          and INPUT.isActionDown('MODIFIER') then
           _long_walk = dir
           _alert = false
           break
@@ -169,7 +172,8 @@ function state:update(dt)
 
     -- execute action
     if _long_walk then
-      if not action_request and _continueLongWalk() then
+      if not action_request and #hostile_bodies == 0
+                            and _continueLongWalk() then
         _startTask(DEFS.ACTION.MOVE, _long_walk)
       else
         _long_walk = false

--- a/game/gamestates/user_turn.lua
+++ b/game/gamestates/user_turn.lua
@@ -129,12 +129,6 @@ function state:update(dt)
     _hideHUD()
   end
 
-  if _next_action then
-    SWITCHER.pop({next_action = _next_action})
-    _next_action = nil
-    return
-  end
-
   if _extended_hud then
     if DIRECTIONALS.wasDirectionTriggered('UP') then
       _view.widget:scrollUp()
@@ -147,9 +141,11 @@ function state:update(dt)
       if DIRECTIONALS.wasDirectionTriggered(dir) then
         if not _long_walk and INPUT.isActionDown('MODIFIER') then
           _long_walk = dir
-        else
-          action_request = {DEFS.ACTION.MOVE, dir}
+          _alert = false
+          break
         end
+        action_request = {DEFS.ACTION.MOVE, dir}
+        break
       end
     end
 
@@ -176,7 +172,6 @@ function state:update(dt)
       if not action_request and _continueLongWalk() then
         _startTask(DEFS.ACTION.MOVE, _long_walk)
       else
-        print("Long Walk end")
         _long_walk = false
       end
     elseif action_request == _OPEN_MENU then
@@ -190,6 +185,12 @@ function state:update(dt)
       _startTask(unpack(action_request))
     end
 
+  end
+
+  if _next_action then
+    SWITCHER.pop({next_action = _next_action})
+    _next_action = nil
+    return
   end
 
   Util.destroyAll()


### PR DESCRIPTION
This PR:
+ Makes longwalk cancelable (press any input to cancel, please update external libs for this)
+ Makes longwalk cancel itself in the presence of harmful bodies
+ Makes longwalk cancel itself when surrounded by a different terrain.

It does not implement drop checkers, because as I did it I realised that drops would need to be unique (have an id, be an actual object), and I wanted to check with the rest of the team before adding more domains to the game (it would involve creating a domain for A Log Of All Seen Drops So Far).

closes #609 