### PR TITLE
Preview card effects

### DIFF
--- a/game/database/domains/card/fireball.json
+++ b/game/database/domains/card/fireball.json
@@ -3,22 +3,7 @@
   "icon":"card-fireball",
   "one_time":false,
   "art":{
-    "cost":40,
     "art_ability":{
-      "inputs":[{
-          "aoe-hint":3,
-          "empty-tile":false,
-          "output":"target",
-          "type":"input",
-          "non-wall":true,
-          "name":"choose_target",
-          "max-range":6
-        },{
-          "type":"operator",
-          "name":"get_attribute",
-          "output":"arc",
-          "which":"ARC"
-        }],
       "effects":[{
           "attr":"=arc",
           "center":"=target",
@@ -27,10 +12,25 @@
           "ignore_owner":false,
           "name":"damage_on_area",
           "base":8
+        }],
+      "inputs":[{
+          "aoe-hint":3,
+          "max-range":6,
+          "name":"choose_target",
+          "type":"input",
+          "empty-tile":false,
+          "output":"target",
+          "non-wall":true
+        },{
+          "type":"operator",
+          "which":"ARC",
+          "name":"get_attribute",
+          "output":"arc"
         }]
-    }
+    },
+    "cost":40
   },
-  "desc":"Deal 12dARC damage in a 3-tile radius area\nsurrounding target position.\n\n\"Ages does by, and the fireball spell remains the\nbread and butter of arcane artists.\"",
+  "desc":"\"Ages does by, and the fireball spell remains the\nbread and butter of arcane artists.\"",
   "type-description":"",
   "pp":0,
   "name":"Fireball",

--- a/game/domain/ability.lua
+++ b/game/domain/ability.lua
@@ -92,5 +92,40 @@ function ABILITY.execute(ability, actor, inputvalues)
   end
 end
 
+function _NOPREVIEW()
+  return nil
+end
+
+function ABILITY.preview(ability, actor, inputvalues)
+  local values = {}
+  local prevs = {}
+  for _,cmdlist in ipairs(_CMDLISTS) do
+    for _,cmd in ipairs(ability[cmdlist]) do
+      local prev, value
+      local type, name = cmd.type, cmd.name
+      local unrefd_field_values = _unrefFieldValues(cmd, values)
+      if type == 'input' then
+        value = inputvalues[cmd.output]
+      else
+        if type == 'operator' then
+          value = OP[name].preview
+        elseif type == 'effect' then
+          prev = FX[name].preview
+        else
+          return error("Invalid command type")
+        end
+      end
+      if cmd.output and value then
+        values[cmd.output] = value(actor, unrefd_field_values)
+      end
+      local text = (prev or _NOPREVIEW)(actor, unrefd_field_values)
+      if text then
+        table.insert(values, text)
+      end
+    end
+  end
+  return table.concat(values, "\n\n")
+end
+
 return ABILITY
 

--- a/game/domain/ability.lua
+++ b/game/domain/ability.lua
@@ -124,7 +124,7 @@ function ABILITY.preview(ability, actor, inputvalues)
       end
     end
   end
-  return table.concat(values, "\n\n")
+  return table.concat(values, ". ") .. "."
 end
 
 return ABILITY

--- a/game/domain/ability.lua
+++ b/game/domain/ability.lua
@@ -105,7 +105,7 @@ function ABILITY.preview(ability, actor, inputvalues)
       local type, name = cmd.type, cmd.name
       local unrefd_field_values = _unrefFieldValues(cmd, values)
       if type == 'input' then
-        value = inputvalues[cmd.output]
+        value = function() return inputvalues[cmd.output] end
       else
         if type == 'operator' then
           value = OP[name].preview
@@ -128,4 +128,3 @@ function ABILITY.preview(ability, actor, inputvalues)
 end
 
 return ABILITY
-

--- a/game/domain/card.lua
+++ b/game/domain/card.lua
@@ -183,9 +183,10 @@ end
 
 function Card:getEffect()
   local effect
+  local inputs = { self = self:getOwner() }
   if self:isArt() then
     effect = ("Art [%d exhaustion]\n\n"):format(self:getArtCost())
-          .. ABILITY.preview(self:getArtAbility(), self:getOwner(), {})
+          .. ABILITY.preview(self:getArtAbility(), self:getOwner(), inputs)
   elseif self:isUpgrade() then
     local ups,n = {}, 0
     for _,up in ipairs(self:getUpgradesList()) do
@@ -205,12 +206,12 @@ function Card:getEffect()
     local activation = self:getWidgetActivation() if activation then
       local ability, cost = activation.ability, activation.cost
       effect = effect .. ("\n\nActivate [%d exhaustion]: "):format(cost)
-                      .. ABILITY.preview(ability, self:getOwner(), {})
+                      .. ABILITY.preview(ability, self:getOwner(), inputs)
     end
     local auto = self:getWidgetTriggeredAbility() if auto then
       local ability, trigger = auto.ability, auto.trigger
       effect = effect .. ("\n\nTrigger [%s]: "):format(trigger)
-                      .. ABILITY.preview(ability, self:getOwner(), {})
+                      .. ABILITY.preview(ability, self:getOwner(), inputs)
     end
     local ops, n = {}, 0
     for _,op in self:getStaticOperators() do

--- a/game/domain/card.lua
+++ b/game/domain/card.lua
@@ -40,6 +40,21 @@ function Card:getDescription()
   return self:getSpec('desc')
 end
 
+function Card:getEffect()
+  local effect
+  if self:isArt() then
+    effect = ("[%d exhaustion]\n\n"):format(self:getArtCost())
+          .. ABILITY.preview(self:getArtAbility(), self:getOwner(), {})
+  elseif self:isUpgrade() then
+    effect = ("Upgrades %s"):format(
+      table.concat(self:getUpgradesList().actor, ', ')
+    )
+  elseif self:isWidget() then
+    effect = "Widget"
+  end
+  return effect .. "\n\n---"
+end
+
 function Card:getIconTexture()
   return self:getSpec('icon')
 end

--- a/game/domain/card.lua
+++ b/game/domain/card.lua
@@ -46,9 +46,11 @@ function Card:getEffect()
     effect = ("[%d exhaustion]\n\n"):format(self:getArtCost())
           .. ABILITY.preview(self:getArtAbility(), self:getOwner(), {})
   elseif self:isUpgrade() then
-    effect = ("Upgrades %s"):format(
-      table.concat(self:getUpgradesList(), ', ')
-    )
+    local ups,n = {}, 1
+    for _,up in ipairs(self:getUpgradesList()) do
+      ups[n] = "+" .. up.val .. " " .. up.attr
+    end
+    effect = ("Upgrades %s"):format(table.concat(ups, ', '))
   elseif self:isWidget() then
     effect = "Widget"
   end

--- a/game/domain/card.lua
+++ b/game/domain/card.lua
@@ -47,7 +47,7 @@ function Card:getEffect()
           .. ABILITY.preview(self:getArtAbility(), self:getOwner(), {})
   elseif self:isUpgrade() then
     effect = ("Upgrades %s"):format(
-      table.concat(self:getUpgradesList().actor, ', ')
+      table.concat(self:getUpgradesList(), ', ')
     )
   elseif self:isWidget() then
     effect = "Widget"

--- a/game/domain/effects/damage_on_area.lua
+++ b/game/domain/effects/damage_on_area.lua
@@ -16,6 +16,13 @@ FX.schema = {
     range = {1} },
 }
 
+function FX.preview (actor, fieldvalues)
+  local attr, base = fieldvalues.attr, fieldvalues.base
+  local min, max = ATTR.DMG(attr, base)
+  local size = fieldvalues['size'] * 2 - 1
+  return ("Deal %s - %s damage on %sx%s area"):format(min, max, size, size)
+end
+
 function FX.process (actor, fieldvalues)
   local sector  = actor:getBody():getSector()
   local ci, cj  = unpack(fieldvalues['center'])

--- a/game/domain/effects/damage_on_target.lua
+++ b/game/domain/effects/damage_on_target.lua
@@ -16,6 +16,12 @@ FX.schema = {
     optional = true },
 }
 
+function FX.preview (actor, fieldvalues)
+  local attr, base = fieldvalues.attr, fieldvalues.base
+  local min, max = ATTR.DMG(attr, base)
+  return ("Deal %s - %s damage to target"):format(min, max)
+end
+
 function FX.process (actor, fieldvalues)
   local attr, base = fieldvalues.attr, fieldvalues.base
   local amount = RANDOM.generate(ATTR.DMG(attr, base))

--- a/game/domain/effects/destroy_body.lua
+++ b/game/domain/effects/destroy_body.lua
@@ -6,6 +6,10 @@ FX.schema = {
   { id = 'target', name = "Target", type = 'value', match = 'body' },
 }
 
+function FX.preview()
+  return "Destroy target body"
+end
+
 function FX.process (actor, fieldvalues)
   fieldvalues.target:exterminate()
 end

--- a/game/domain/effects/draw_card.lua
+++ b/game/domain/effects/draw_card.lua
@@ -6,6 +6,10 @@ FX.schema = {
     range = {1} }, 
 }
 
+function FX.preview(actor, fieldvalues)
+  return ("Draw %s cards"):format(fieldvalues['amount'])
+end
+
 function FX.process (actor, fieldvalues)
   for i = 1, fieldvalues.amount do
     actor:drawCard()

--- a/game/domain/effects/give_pack.lua
+++ b/game/domain/effects/give_pack.lua
@@ -6,6 +6,10 @@ FX.schema = {
     type = 'enum', options = 'domains.collection' }, 
 }
 
+function FX.preview()
+  return "Get card pack"
+end
+
 function FX.process (actor, fieldvalues)
   actor:addPrizePack(fieldvalues['collection'])
   coroutine.yield('report', {

--- a/game/domain/effects/heal.lua
+++ b/game/domain/effects/heal.lua
@@ -7,7 +7,11 @@ FX.schema = {
     range = {0} },
 }
 
-function FX.process (actor, fieldvalues)
+function FX.preview(actor, fieldvalues)
+  return ("Heal %s hit points"):format(fieldvalues['amount'])
+end
+
+function FX.process(actor, fieldvalues)
   fieldvalues.target:heal(fieldvalues.amount or 2)
   coroutine.yield('report', {
     type = 'text_rise',

--- a/game/domain/effects/lose_life.lua
+++ b/game/domain/effects/lose_life.lua
@@ -13,6 +13,14 @@ FX.schema = {
 
 -- can be for self-damaging attacks, as well as effects like poison
 
+function FX.preview(actor, fieldvalues)
+  local str = ("Lose %s%% hit points"):format(fieldvalues['percentage'])
+  if fieldvalues['stay_alive'] then
+    str = str .. " (non-lethal)"
+  end
+  return  str
+end
+
 function FX.process (actor, fieldvalues)
   local body = actor:getBody()
   local current_hp = body:getHP()

--- a/game/domain/effects/make_body.lua
+++ b/game/domain/effects/make_body.lua
@@ -1,5 +1,6 @@
 
 local Card = require 'domain.card'
+local DB = require 'database'
 local FX = {}
 
 FX.schema = {
@@ -18,6 +19,11 @@ FX.schema = {
     }
   }
 }
+
+function FX.preview(_, fieldvalues)
+  local name = DB.loadSpec('body', fieldvalues['bodyspec'])['name']
+  return ("Create %s"):format(name)
+end
 
 function FX.process (actor, fieldvalues)
   local sector = actor:getBody():getSector()

--- a/game/domain/effects/make_body.lua
+++ b/game/domain/effects/make_body.lua
@@ -22,7 +22,18 @@ FX.schema = {
 
 function FX.preview(_, fieldvalues)
   local name = DB.loadSpec('body', fieldvalues['bodyspec'])['name']
-  return ("Create %s"):format(name)
+  local str = ("Create %s"):format(name)
+  local widgets = fieldvalues['widgets']
+  if widgets and #widgets > 0 then
+    str = str .. " with "
+    local list, n = {}, 0
+    for _,widget in ipairs(widgets) do
+      n = n + 1
+      list[n] = DB.loadSpec('card', widget.spec)['name']
+    end
+    str = str .. table.concat(list, ', ')
+  end
+  return str
 end
 
 function FX.process (actor, fieldvalues)

--- a/game/domain/effects/move_to.lua
+++ b/game/domain/effects/move_to.lua
@@ -13,6 +13,10 @@ FX.schema = {
     optional = true },
 }
 
+function FX.preview(_, fieldvalues)
+  return "Movement effect"
+end
+
 function FX.process (actor, fieldvalues)
   local pos = {actor:getPos()}
   local body = fieldvalues['body']

--- a/game/domain/effects/place_widget.lua
+++ b/game/domain/effects/place_widget.lua
@@ -1,5 +1,6 @@
 
 local Card = require 'domain.card'
+local DB = require 'database'
 
 local FX = {}
 
@@ -8,6 +9,11 @@ FX.schema = {
   { id = 'card', name = "Card Specname", type = 'enum',
     options = "domains.card" },
 }
+
+function FX.preview(_, fieldvalues)
+  local name = DB.loadSpec('card', fieldvalues['card'])['name']
+  return ("Cause %s"):format(name)
+end
 
 function FX.process(actor, fieldvalues)
   local card = Card(fieldvalues['card'])

--- a/game/domain/effects/place_widget_on_area.lua
+++ b/game/domain/effects/place_widget_on_area.lua
@@ -1,5 +1,6 @@
 
 local RANDOM = require 'common.random'
+local DB = require 'database'
 local Card = require 'domain.card'
 local FX = {}
 
@@ -11,6 +12,12 @@ FX.schema = {
   { id = 'card', name = "Card Specname", type = 'enum',
     options = "domains.card" },
 }
+
+function FX.preview(_, fieldvalues)
+  local name = DB.loadSpec('card', fieldvalues['card'])['name']
+  local size = fieldvalues['size'] * 2 - 1
+  return ("Cause %s on %sx%s area"):format(name, size, size)
+end
 
 function FX.process (actor, fieldvalues)
   local sector        = actor:getBody():getSector()

--- a/game/domain/effects/print.lua
+++ b/game/domain/effects/print.lua
@@ -6,6 +6,10 @@ FX.schema = {
     range = {0} }
 }
 
+function FX.preview()
+  return "Debug"
+end
+
 function FX.process (actor,fieldvalues)
   print(fieldvalues.text)
 end

--- a/game/domain/effects/reward_pp.lua
+++ b/game/domain/effects/reward_pp.lua
@@ -9,6 +9,10 @@ FX.schema = {
     match = 'body' },
 }
 
+function FX.preview()
+  return ("Give %s PP"):format(fieldvalues['amount'])
+end
+
 function FX.process (actor, fieldvalues)
   local target = fieldvalues['target']
   local amount = fieldvalues['amount']

--- a/game/domain/operators/count_nearby_bodies.lua
+++ b/game/domain/operators/count_nearby_bodies.lua
@@ -38,5 +38,7 @@ function OP.process(actor, fieldvalues)
   return count
 end
 
+OP.preview = OP.process
+
 return OP
 

--- a/game/domain/operators/dice_throw.lua
+++ b/game/domain/operators/dice_throw.lua
@@ -12,6 +12,10 @@ OP.schema = {
 
 OP.type = 'integer'
 
+function OP.preview(actor, fieldvalues)
+  return ("%sd%s"):format(fieldvalues['rolls'], fieldvalues['sides'])
+end
+
 function OP.process(actor, fieldvalues)
   return RANDOM.rollDice(fieldvalues.rolls, fieldvalues.sides)
 end

--- a/game/domain/operators/get_actor_body.lua
+++ b/game/domain/operators/get_actor_body.lua
@@ -14,5 +14,7 @@ function OP.process(actor, fieldvalues)
   return actor:getBody()
 end
 
+OP.preview = OP.process
+
 return OP
 

--- a/game/domain/operators/get_attribute.lua
+++ b/game/domain/operators/get_attribute.lua
@@ -15,5 +15,7 @@ function OP.process(actor, fieldvalues)
   return actor["get"..fieldvalues.which](actor)
 end
 
+OP.preview = OP.process
+
 return OP
 

--- a/game/domain/operators/get_body_pos.lua
+++ b/game/domain/operators/get_body_pos.lua
@@ -14,4 +14,6 @@ function OP.process(actor, fieldvalues)
   return { fieldvalues['body']:getPos() }
 end
 
+OP.preview = OP.process
+
 return OP

--- a/game/domain/operators/integer_binop.lua
+++ b/game/domain/operators/integer_binop.lua
@@ -27,4 +27,6 @@ function OP.process(actor, fieldvalues)
 
 end
 
+OP.preview = OP.process
+
 return OP

--- a/game/domain/operators/self.lua
+++ b/game/domain/operators/self.lua
@@ -13,5 +13,7 @@ function OP.process(actor, fieldvalues)
   return actor
 end
 
+OP.preview = OP.process
+
 return OP
 

--- a/game/view/helpers/card.lua
+++ b/game/view/helpers/card.lua
@@ -39,8 +39,12 @@ function _DRAW:getName()
   return "New Hand"
 end
 
-function _DRAW:getDescription()
+function _DRAW:getEffect()
   return "Discard your hand, draw five cards, spend PP"
+end
+
+function _DRAW:getDescription()
+  return ""
 end
 
 function _DRAW:getIconTexture()
@@ -144,7 +148,8 @@ function CARD.drawInfo(card, x, y, width, alpha)
   g.translate(0, _title_font:getHeight())
 
   _text_font.set()
-  local desc = card:getDescription() or "[No description]"
+  local desc = card:getEffect()
+  desc = desc .. '\n\n' .. (card:getDescription() or "[No description]")
   desc = desc:gsub("([^\n])[\n]([^\n])", "%1 %2")
   desc = desc:gsub("\n\n", "\n")
   g.printf(desc, 0, 0, width)


### PR DESCRIPTION
Generates an automatic description previewing the effect of cards.

Depends on #746 

The generated descriptions are not complete, but I think are quite sufficient. For instance, cards that move things ("Jump", "Rush", etc.) get an "Movement effect" description, but if you try to use the card and think a little, it's hopefully easy to see the kind of movement it provides.

All in all, this is a very simple but limited solution that should get the job done. Further improvements can come later.