### PR TITLE
Uniformize domain builders

### DIFF
--- a/game/database/schema/actor.lua
+++ b/game/database/schema/actor.lua
@@ -7,14 +7,20 @@ do
 end
 
 return {
-  { id = 'extends', name = "Prototype", type = 'enum', options = 'domains.actor',
-    optional = true },
+  { id = 'extends', name = "Prototype", type = 'enum',
+    options = 'domains.actor', optional = true },
   { id = 'name', name = "Full Name", type = 'string' },
   { id = 'description', name = "Description", type = 'text' },
   { id = 'behavior', name = "Behavior", type = 'enum',
     options = behaviors },
   { id = 'signature', name = "Signature Ability", type = 'enum',
     options = 'domains.action' },
+  { id = 'traits', name = "Traits", type = 'array',
+    schema = {
+      { id = 'specname', name = "Trait", type = 'enum',
+      options = "domains.card" },
+    }
+  },
   { id = 'cor', name = "COR Aptitude", type = 'range', min = -2, max = 2 },
   { id = 'arc', name = "ARC Aptitude", type = 'range', min = -2, max = 2 },
   { id = 'ani', name = "ANI Aptitude", type = 'range', min = -2, max = 2 },

--- a/game/domain/actor.lua
+++ b/game/domain/actor.lua
@@ -56,16 +56,16 @@ function Actor:init(spec_name)
 end
 
 function Actor:loadState(state)
-  self.cooldown = state.cooldown
-  self.body_id = state.body_id
-  self:setId(state.id)
-  self.exp = state.exp
-  self.playpoints = state.playpoints
-  self.upgrades = state.upgrades
+  self.cooldown = state.cooldown or self.cooldown
+  self.body_id = state.body_id or self.body_id
+  self:setId(state.id or self.id)
+  self.exp = state.exp or self.exp
+  self.playpoints = state.playpoints or self.playpoints
+  self.upgrades = state.upgrades or self.upgrades
   self.attr_lv = {}
-  self.prizes = state.prizes
-  self.hand_limit = state.hand_limit
-  self.hand = {}
+  self.prizes = state.prizes or self.prizes
+  self.hand_limit = state.hand_limit or self.hand_limit
+  self.hand = state.hand and {} or self.hand
   for _,card_state in ipairs(state.hand) do
     local card = Card(card_state.specname)
     card:loadState(card_state)
@@ -74,7 +74,7 @@ function Actor:loadState(state)
     end
     table.insert(self.hand, card)
   end
-  self.buffer = {}
+  self.buffer = state.buffer and {} or self.buffer
   for i,card_state in ipairs(state.buffer) do
     local card = DEFS.DONE
     if card_state ~= card then

--- a/game/domain/body.lua
+++ b/game/domain/body.lua
@@ -33,13 +33,13 @@ function Body:init(specname)
 end
 
 function Body:loadState(state)
-  self.damage = state.damage
-  self.killer = state.killer
+  self.damage = state.damage or self.damage
+  self.killer = state.killer or false
+  self.upgrades = state.upgrades or self.upgrades
   self.attr_lv = {}
-  self.sector_id = state.sector_id
-  self:setId(state.id)
-  self.equipped = state.equipped
-  self.widgets = {}
+  self.sector_id = state.sector_id or self.sector_id
+  self:setId(state.id or self.id)
+  self.widgets = state.widgets and {} or self.widgets
   for index, card_state in pairs(state.widgets) do
     if card_state then
       local card = Card(card_state.specname)
@@ -47,6 +47,16 @@ function Body:loadState(state)
       self.widgets[index] = card
     end
   end
+  local equipped = self.equipped
+  if state.equipped then
+    equipped = {}
+    for _,placement in ipairs(PLACEMENTS) do
+      equipped[placement] = self.widgets[state.equipped[placement]]
+    end
+  end
+  self.equipped = equipped
+  self:updateAttr('DEF')
+  self:updateAttr('VIT')
 end
 
 function Body:saveState()
@@ -56,7 +66,15 @@ function Body:saveState()
   state.killer = self.killer
   state.sector_id = self.sector_id
   state.id = self.id
-  state.equipped = self.equipped
+  local equipped = {}
+  for _,placement in ipairs(DEFS.PLACEMENTS) do
+    local equip = self:getEquipmentAt(placement)
+    if equip then
+      local index = self:findWidget(equip)
+      equipped[placement] = index
+    end
+  end
+  state.equipped = equipped
   state.widgets = {}
   for index, card in pairs(self.widgets) do
     if card then
@@ -264,6 +282,15 @@ end
 function Body:getWidgetNameAt(index)
   local card = self.widgets[index]
   if card then return card:getName() end
+end
+
+function Body:findWidget(target)
+  for index, widget in self:eachWidget() do
+    if widget == target then
+      return index
+    end
+  end
+  return -1
 end
 
 function Body:spendWidget(index)

--- a/game/domain/body.lua
+++ b/game/domain/body.lua
@@ -35,7 +35,6 @@ end
 function Body:loadState(state)
   self.damage = state.damage or self.damage
   self.killer = state.killer or false
-  self.upgrades = state.upgrades or self.upgrades
   self.attr_lv = {}
   self.sector_id = state.sector_id or self.sector_id
   self:setId(state.id or self.id)
@@ -55,8 +54,6 @@ function Body:loadState(state)
     end
   end
   self.equipped = equipped
-  self:updateAttr('DEF')
-  self:updateAttr('VIT')
 end
 
 function Body:saveState()
@@ -67,7 +64,7 @@ function Body:saveState()
   state.sector_id = self.sector_id
   state.id = self.id
   local equipped = {}
-  for _,placement in ipairs(DEFS.PLACEMENTS) do
+  for _,placement in ipairs(PLACEMENTS) do
     local equip = self:getEquipmentAt(placement)
     if equip then
       local index = self:findWidget(equip)

--- a/game/domain/builders/actor.lua
+++ b/game/domain/builders/actor.lua
@@ -7,15 +7,19 @@ local Actor          = require 'domain.actor'
 
 local BUILDER = {}
 
-function BUILDER.build(idgenerator, background, body_state, is_state)
+function BUILDER.buildState(idgenerator, background, body_state)
+  -- WARNING: Do not instantiate body before building the actor!
+  -- Build only bodystate instead. If not possible (body already exists),
+  -- you will have to reload its state after calling this function. If so,
+  -- do not lose the 'body_state' reference, as it is edited in-place here.
   local traits_specs = DB.loadSpec('actor', background)['traits']
   if traits_specs then
     for _,trait_spec in ipairs(traits_specs) do
-      local trait = CARD_BUILDER.build(trait_spec.specname, true)
+      local trait = CARD_BUILDER.buildState(trait_spec.specname, true)
       table.insert(body_state.widgets, trait)
     end
   end
-  local state = {
+  return {
     id = idgenerator.newID(),
     body_id = body_state.id,
     specname = background,
@@ -32,13 +36,13 @@ function BUILDER.build(idgenerator, background, body_state, is_state)
     hand = {},
     prizes = {},
   }
-  if is_state then
-    return state
-  else
-    local actor = Actor(background)
-    actor:loadState(state)
-    return actor
-  end
+end
+
+function BUILDER.buildElement(idgenerator, background, body_state)
+  local state = BUILDER.buildState(idgenerator, background, body_state)
+  local actor = Actor(background)
+  actor:loadState(state)
+  return actor
 end
 
 return BUILDER

--- a/game/domain/builders/actor.lua
+++ b/game/domain/builders/actor.lua
@@ -1,13 +1,17 @@
 
+local DB = require 'database'
 local BUFFER_BUILDER = require 'domain.builders.buffers'
-local DEFS = require 'domain.definitions'
+local DEFS           = require 'domain.definitions'
+local Card           = require 'domain.card'
 
 local BUILDER = {}
 
-function BUILDER.build(idgenerator, body_id, background)
+function BUILDER.build(idgenerator, background, body_state)
+  local signature = Card(DB.loadSpec('actor', background)['signature'])
+  table.insert(body_state.widgets, signature:saveState())
   return {
     id = idgenerator.newID(),
-    body_id = body_id,
+    body_id = body_state.id,
     specname = background,
     cooldown = 10,
     exp = 0,

--- a/game/domain/builders/actor.lua
+++ b/game/domain/builders/actor.lua
@@ -1,5 +1,5 @@
 
-local DB = require 'database'
+local DB             = require 'database'
 local CARD_BUILDER   = require 'domain.builders.card'
 local BUFFER_BUILDER = require 'domain.builders.buffers'
 local DEFS           = require 'domain.definitions'

--- a/game/domain/builders/actor.lua
+++ b/game/domain/builders/actor.lua
@@ -1,15 +1,21 @@
 
 local DB = require 'database'
+local CARD_BUILDER   = require 'domain.builders.card'
 local BUFFER_BUILDER = require 'domain.builders.buffers'
 local DEFS           = require 'domain.definitions'
-local Card           = require 'domain.card'
+local Actor          = require 'domain.actor'
 
 local BUILDER = {}
 
-function BUILDER.build(idgenerator, background, body_state)
-  local signature = Card(DB.loadSpec('actor', background)['signature'])
-  table.insert(body_state.widgets, signature:saveState())
-  return {
+function BUILDER.build(idgenerator, background, body_state, is_state)
+  local traits_specs = DB.loadSpec('actor', background)['traits']
+  if traits_specs then
+    for _,trait_spec in ipairs(traits_specs) do
+      local trait = CARD_BUILDER.build(trait_spec.specname, true)
+      table.insert(body_state.widgets, trait)
+    end
+  end
+  local state = {
     id = idgenerator.newID(),
     body_id = body_state.id,
     specname = background,
@@ -26,6 +32,13 @@ function BUILDER.build(idgenerator, background, body_state)
     hand = {},
     prizes = {},
   }
+  if is_state then
+    return state
+  else
+    local actor = Actor(background)
+    actor:loadState(state)
+    return actor
+  end
 end
 
 return BUILDER

--- a/game/domain/builders/body.lua
+++ b/game/domain/builders/body.lua
@@ -8,10 +8,6 @@ function BUILDER.buildState(idgenerator, species, i, j)
     id = idgenerator.newID(),
     specname = species,
     damage = 0,
-    upgrades = {
-      DEF = 100,
-      VIT = 100,
-    },
     i = i,
     j = j,
     equipped = {

--- a/game/domain/builders/body.lua
+++ b/game/domain/builders/body.lua
@@ -1,22 +1,35 @@
 
+local Body require 'domain.body'
+
 local BUILDER = {}
 
-function BUILDER.build(idgenerator, species, i, j)
-  return {
-    id = idgenerator.newID(),
-    specname = species,
-    damage = 0,
-    i = i,
-    j = j,
-    equipped = {
-      weapon = false,
-      offhand = false,
-      suit = false,
-      tool = false,
-      accessory = false,
-    },
-    widgets = {},
-  }
+function BUILDER.build(idgenerator, species, i, j, is_state)
+  local state = {
+      id = idgenerator.newID(),
+      specname = species,
+      damage = 0,
+      upgrades = {
+        DEF = 100,
+        VIT = 100,
+      },
+      i = i,
+      j = j,
+      equipped = {
+        weapon = false,
+        offhand = false,
+        suit = false,
+        tool = false,
+        accessory = false,
+      },
+      widgets = {},
+    }
+  if is_state then
+    return state
+  else
+    local body = Body(species)
+    body:loadState(state)
+    return body
+  end
 end
 
 return BUILDER

--- a/game/domain/builders/body.lua
+++ b/game/domain/builders/body.lua
@@ -3,33 +3,33 @@ local Body require 'domain.body'
 
 local BUILDER = {}
 
-function BUILDER.build(idgenerator, species, i, j, is_state)
-  local state = {
-      id = idgenerator.newID(),
-      specname = species,
-      damage = 0,
-      upgrades = {
-        DEF = 100,
-        VIT = 100,
-      },
-      i = i,
-      j = j,
-      equipped = {
-        weapon = false,
-        offhand = false,
-        suit = false,
-        tool = false,
-        accessory = false,
-      },
-      widgets = {},
-    }
-  if is_state then
-    return state
-  else
-    local body = Body(species)
-    body:loadState(state)
-    return body
-  end
+function BUILDER.buildState(idgenerator, species, i, j)
+  return {
+    id = idgenerator.newID(),
+    specname = species,
+    damage = 0,
+    upgrades = {
+      DEF = 100,
+      VIT = 100,
+    },
+    i = i,
+    j = j,
+    equipped = {
+      weapon = false,
+      offhand = false,
+      suit = false,
+      tool = false,
+      accessory = false,
+    },
+    widgets = {},
+  }
+end
+
+function BUILDER.buildElement(idgenerator, species, i, j)
+  local state = BUILDER.buildState(idgenerator, species, i, j)
+  local body = Body(species)
+  body:loadState(state)
+  return body
 end
 
 return BUILDER

--- a/game/domain/builders/body.lua
+++ b/game/domain/builders/body.lua
@@ -1,5 +1,5 @@
 
-local Body require 'domain.body'
+local Body = require 'domain.body'
 
 local BUILDER = {}
 

--- a/game/domain/builders/buffers.lua
+++ b/game/domain/builders/buffers.lua
@@ -3,13 +3,13 @@ local DB = require 'database'
 local RANDOM = require 'common.random'
 local DEFS = require 'domain.definitions'
 
-local _buildCard = require 'domain.builders.card' .build
+local _buildCard = require 'domain.builders.card' .buildState
 
 function BUILDER.build(background)
   local buffer = {}
   for _,cardinfo in ipairs(DB.loadSpec('actor', background).initial_buffer) do
     for i = 1, cardinfo.amount do
-      table.insert(buffer, _buildCard(cardinfo.card, true))
+      table.insert(buffer, _buildCard(cardinfo.card))
     end
   end
   RANDOM.shuffle(buffer)

--- a/game/domain/builders/buffers.lua
+++ b/game/domain/builders/buffers.lua
@@ -2,20 +2,14 @@
 local DB = require 'database'
 local RANDOM = require 'common.random'
 local DEFS = require 'domain.definitions'
-local BUILDER = {}
 
-local function _card(specname)
-  return {
-    specname = specname,
-    usages = 0,
-  }
-end
+local _buildCard = require 'domain.builders.card' .build
 
 function BUILDER.build(background)
   local buffer = {}
   for _,cardinfo in ipairs(DB.loadSpec('actor', background).initial_buffer) do
     for i = 1, cardinfo.amount do
-      table.insert(buffer, _card(cardinfo.card))
+      table.insert(buffer, _buildCard(cardinfo.card, true))
     end
   end
   RANDOM.shuffle(buffer)

--- a/game/domain/builders/buffers.lua
+++ b/game/domain/builders/buffers.lua
@@ -5,6 +5,8 @@ local DEFS = require 'domain.definitions'
 
 local _buildCard = require 'domain.builders.card' .buildState
 
+local BUILDER = {}
+
 function BUILDER.build(background)
   local buffer = {}
   for _,cardinfo in ipairs(DB.loadSpec('actor', background).initial_buffer) do

--- a/game/domain/builders/card.lua
+++ b/game/domain/builders/card.lua
@@ -3,18 +3,18 @@ local Card = require 'domain.card'
 
 local BUILDER = {}
 
-function BUILDER.build(specname, is_state)
-  local state = {
+function BUILDER.buildState(specname)
+  return {
     specname = specname,
     usages = 0,
   }
-  if is_state then
-    return state
-  else
-    local card = Card(specname)
-    card:loadState(state)
-    return card
-  end
+end
+
+function BUILDER.buildElement(specname)
+  local state = BUILDER.buildState(specname)
+  local card = Card(specname)
+  card:loadState(state)
+  return card
 end
 
 return BUILDER

--- a/game/domain/builders/card.lua
+++ b/game/domain/builders/card.lua
@@ -1,0 +1,21 @@
+
+local Card = require 'domain.card'
+
+local BUILDER = {}
+
+function BUILDER.build(specname, is_state)
+  local state = {
+    specname = specname,
+    usages = 0,
+  }
+  if is_state then
+    return state
+  else
+    local card = Card(specname)
+    card:loadState(state)
+    return card
+  end
+end
+
+return BUILDER
+

--- a/game/domain/builders/sectors.lua
+++ b/game/domain/builders/sectors.lua
@@ -28,8 +28,8 @@ function BUILDER.build(idgenerator, player_data)
   -- generate player
   local species = player_data.species
   local background = player_data.background
-  local pbody = BODY_BUILDER.build(idgenerator, species, 16, 12, true)
-  local pactor = ACTOR_BUILDER.build(idgenerator, background, pbody, true)
+  local pbody = BODY_BUILDER.buildState(idgenerator, species, 16, 12)
+  local pactor = ACTOR_BUILDER.buildState(idgenerator, background, pbody)
 
   -- generate first sector
   local tiledata = DB.loadSetting('init_tiledata')

--- a/game/domain/builders/sectors.lua
+++ b/game/domain/builders/sectors.lua
@@ -29,7 +29,7 @@ function BUILDER.build(idgenerator, player_data)
   local species = player_data.species
   local background = player_data.background
   local pbody = BODY_BUILDER.build(idgenerator, species, 16, 12)
-  local pactor = ACTOR_BUILDER.build(idgenerator, pbody.id, background)
+  local pactor = ACTOR_BUILDER.build(idgenerator, background, pbody)
 
   -- generate first sector
   local tiledata = DB.loadSetting('init_tiledata')

--- a/game/domain/builders/sectors.lua
+++ b/game/domain/builders/sectors.lua
@@ -28,8 +28,8 @@ function BUILDER.build(idgenerator, player_data)
   -- generate player
   local species = player_data.species
   local background = player_data.background
-  local pbody = BODY_BUILDER.build(idgenerator, species, 16, 12)
-  local pactor = ACTOR_BUILDER.build(idgenerator, background, pbody)
+  local pbody = BODY_BUILDER.build(idgenerator, species, 16, 12, true)
+  local pactor = ACTOR_BUILDER.build(idgenerator, background, pbody, true)
 
   -- generate first sector
   local tiledata = DB.loadSetting('init_tiledata')

--- a/game/domain/card.lua
+++ b/game/domain/card.lua
@@ -17,10 +17,10 @@ function Card:init(specname)
 end
 
 function Card:loadState(state)
-  self.specname = state.specname
-  self.usages = state.usages
-  self.owner_id = state.owner_id
-  self.ticks = state.ticks
+  self.specname = state.specname or self.specname
+  self.usages = state.usages or self.usages
+  self.owner_id = state.owner_id or self.owner_id
+  self.ticks = state.ticks or self.ticks
 end
 
 function Card:saveState()

--- a/game/domain/effects/make_body.lua
+++ b/game/domain/effects/make_body.lua
@@ -40,8 +40,8 @@ function FX.process (actor, fieldvalues)
   local sector = actor:getBody():getSector()
   local bodyspec = fieldvalues['bodyspec']
   local i,j = unpack(fieldvalues['pos'])
-  local body = sector:getRoute().makeBody(bodyspec, i, j)
-  local state = {}
+  local body = sector:getRoute().makeBody(sector, bodyspec, i, j)
+  local state = body:saveState()
   state.widgets = {}
   for _,widget_fieldvalues in ipairs(fieldvalues['widgets']) do
     local widgetspec = widget_fieldvalues['spec']
@@ -52,11 +52,7 @@ function FX.process (actor, fieldvalues)
       table.insert(state.widgets, widget)
     end
   end
-  state.upgrades = {
-    VIT = fieldvalues['vit'],
-    DEF = fieldvalues['def'],
-  }
-  body:loadState(setmetatable(state, { __index = body:saveState() }))
+  body:loadState(state)
 end
 
 return FX

--- a/game/domain/route.lua
+++ b/game/domain/route.lua
@@ -5,6 +5,7 @@ local IDGenerator = require 'common.idgenerator'
 local RANDOM = require 'common.random'
 local PROFILE = require 'infra.profile'
 
+local BUILDERS = require 'lux.pack' 'domain.builders'
 local Body = require 'domain.body'
 local Actor = require 'domain.actor'
 local Sector = require 'domain.sector'
@@ -121,12 +122,16 @@ function Route:instance(obj)
   end
 
   function obj.makeBody(bodyspec, i, j)
-    local bid, body = _register(Body(bodyspec))
+    local body_state = BUILDERS.body.build(_id_generator, bodyspec, i, j)
+    local body = Body(bodyspec)
+    body:loadState(body_state)
+    _register(body)
     _current_sector:putBody(body, i, j)
     return body
   end
 
   function obj.makeActor(bodyspec, actorspec, i, j)
+
     local bid, body = _register(Body(bodyspec))
     local aid, actor = _register(Actor(actorspec))
     actor:setBody(bid)

--- a/game/domain/route.lua
+++ b/game/domain/route.lua
@@ -113,7 +113,7 @@ function Route:instance(obj)
     if not exit.target_pos then
       local to_sector = Util.findId(target_sector_id)
       if not to_sector:isGenerated() then
-        to_sector:generate(_register)
+        to_sector:generate()
       end
       local entry = to_sector:getExit(from_sector.id)
       to_sector:link(from_sector.id, unpack(exit.pos))
@@ -121,22 +121,22 @@ function Route:instance(obj)
     end
   end
 
-  function obj.makeBody(bodyspec, i, j)
-    local body_state = BUILDERS.body.build(_id_generator, bodyspec, i, j)
-    local body = Body(bodyspec)
-    body:loadState(body_state)
+  function obj.makeBody(sector, bodyspec, i, j)
+    local body = BUILDERS.body.buildElement(_id_generator, bodyspec, i, j)
     _register(body)
-    _current_sector:putBody(body, i, j)
+    sector:putBody(body, i, j)
     return body
   end
 
-  function obj.makeActor(bodyspec, actorspec, i, j)
-
-    local bid, body = _register(Body(bodyspec))
-    local aid, actor = _register(Actor(actorspec))
-    actor:setBody(bid)
-    _current_sector:putActor(actor, i, j)
-    return actor
+  function obj.makeActor(sector, actorspec, bodyspec, i, j)
+    local b_state = BUILDERS.body.buildState(_id_generator, bodyspec, i, j)
+    local actor = BUILDERS.actor.buildElement(_id_generator, actorspec, b_state)
+    local body = Body(bodyspec)
+    body:loadState(b_state)
+    _register(actor)
+    _register(body)
+    sector:putActor(actor, i, j)
+    return actor, body
   end
 
   function obj.getPlayerActor()

--- a/game/domain/sector.lua
+++ b/game/domain/sector.lua
@@ -144,7 +144,7 @@ function Sector:isGenerated()
   return self.generated
 end
 
-function Sector:generate(register)
+function Sector:generate()
 
   -- load sector's specs
   local base = {
@@ -160,7 +160,7 @@ function Sector:generate(register)
   end
 
   self:makeTiles(base.grid, base.drops)
-  self:makeEncounters(base.encounters, register)
+  self:makeEncounters(base.encounters)
 
   self.generated = true
 end
@@ -189,12 +189,11 @@ function Sector:makeTiles(grid, drops)
   end
 end
 
-function Sector:makeEncounters(encounters, register)
+function Sector:makeEncounters(encounters)
   for _,encounter in ipairs(encounters) do
-    local actor_spec, body_spec = unpack(encounter.monster)
+    local actorspec, bodyspec = unpack(encounter.monster)
     local i, j = unpack(encounter.pos)
-    local bid, body = register(Body(body_spec))
-    local aid, actor = register(Actor(actor_spec))
+    local actor, body = self.route.makeActor(self, actorspec, bodyspec, i, j)
     local difficulty_multiplier = 1 + self:getDifficulty()
     local upgradexp = encounter.upgrade_power
 
@@ -216,10 +215,6 @@ function Sector:makeEncounters(encounters, register)
         end
       end
     end
-
-    -- putting actor and body in sector
-    actor:setBody(bid)
-    self:putActor(actor, i, j)
   end
 end
 


### PR DESCRIPTION
Refactors actor/body save/load methods, which closes #761 

This centralizes actor and body generation in the builders, and revamps route's `makeActor` and `makeBody` methods. Adjust rest of code accordigly.

Also this is necessary for #451 , as it introduces the "traits" spec on the actor, which will specify their base abilities.