### PR TITLE
Refactor gamestate manager to allow update on drawables

### DIFF
--- a/game/draw.lua
+++ b/game/draw.lua
@@ -14,6 +14,17 @@ local draw = {}
 --BASIC DRAW FUNCTIONS
 ----------------------
 
+--Update every drawable object
+function draw.update(dt)
+  for _,layer in pairs(DRAW_TABLE) do
+    for o in pairs(layer) do
+      if not o.death and not o.invisible and o.update then
+        o:update(dt)
+      end
+    end
+  end
+end
+
 --Draws every drawable object from all tables
 function draw.allTables()
 

--- a/game/gamestates/animation.lua
+++ b/game/gamestates/animation.lua
@@ -31,8 +31,6 @@ end
 
 function state:update(dt)
 
-  MAIN_TIMER:update(dt)
-
   if INPUT.wasAnyPressed(0.5) then
     _alert = true
   end

--- a/game/gamestates/card_select.lua
+++ b/game/gamestates/card_select.lua
@@ -66,7 +66,6 @@ end
 function state:update(dt)
 
   if DEBUG then return end
-  MAIN_TIMER:update(dt)
 
   if DIRECTIONALS.wasDirectionTriggered('RIGHT') then
     _moveFocus("RIGHT")

--- a/game/gamestates/character_build.lua
+++ b/game/gamestates/character_build.lua
@@ -50,7 +50,6 @@ function state:leave()
 end
 
 function state:update(dt)
-  MAIN_TIMER:update(dt)
 
   if _leave then return end
 

--- a/game/gamestates/consume_cards.lua
+++ b/game/gamestates/consume_cards.lua
@@ -52,8 +52,6 @@ end
 function state:update(dt)
   if DEBUG then return end
 
-  MAIN_TIMER:update(dt)
-
   if _leave then
     PLAYSFX 'back-menu'
     SWITCHER.pop({})

--- a/game/gamestates/manage_buffer.lua
+++ b/game/gamestates/manage_buffer.lua
@@ -45,8 +45,6 @@ end
 function state:update(dt)
   if DEBUG then return end
 
-  MAIN_TIMER:update(dt)
-
   if _leave or _view:isCardListEmpty() then
     PLAYSFX 'back-menu'
     SWITCHER.pop()

--- a/game/gamestates/open_pack.lua
+++ b/game/gamestates/open_pack.lua
@@ -78,8 +78,6 @@ end
 function state:update(dt)
   if DEBUG then return end
 
-  MAIN_TIMER:update(dt)
-
   if _status == "choosing_pack" and
      (_leave or _card_list_view:isPackListEmpty()) then
     PLAYSFX 'back-menu'

--- a/game/gamestates/pick_dir.lua
+++ b/game/gamestates/pick_dir.lua
@@ -38,8 +38,6 @@ function state:leave()
 end
 
 function state:update(dt)
-  MAIN_TIMER:update(dt)
-
   if INPUT.wasActionPressed('CONFIRM') then
     _sector_view:setRayDir()
     SWITCHER.pop(_current_dir)

--- a/game/gamestates/pick_target.lua
+++ b/game/gamestates/pick_target.lua
@@ -76,7 +76,6 @@ end
 function state:update(dt)
   if DEBUG then return end
 
-  MAIN_TIMER:update(dt)
   _sector_view:lookAtCursor()
 
   if INPUT.wasActionPressed('CONFIRM') then

--- a/game/gamestates/pick_widget_slot.lua
+++ b/game/gamestates/pick_widget_slot.lua
@@ -50,7 +50,6 @@ end
 
 function state:update(dt)
   if not DEBUG then
-    MAIN_TIMER:update(dt)
     if _leave then
       (_view and _view.fadeOut or DEFS.NULL_METHOD)(_view)
       SWITCHER.pop({})

--- a/game/gamestates/play.lua
+++ b/game/gamestates/play.lua
@@ -180,7 +180,6 @@ function state:update(dt)
       _alert = true
     end
 
-    MAIN_TIMER:update(dt)
     if _next_action then
       _playTurns(unpack(_next_action))
     end

--- a/game/gamestates/play.lua
+++ b/game/gamestates/play.lua
@@ -167,8 +167,15 @@ function state:leave()
 end
 
 function state:update(dt)
-
   if not DEBUG then
+
+    --FIXME:this doesn't need to happen every update (I think)
+    if _route.getControlledActor() or _player then
+      _view.sector:updateFov(_route.getControlledActor() or _player)
+    else
+      print("oops")
+    end
+
     if INPUT.wasAnyPressed(0.5) then
       _alert = true
     end
@@ -197,16 +204,7 @@ function state:resume(state, args)
 end
 
 function state:draw()
-
-  --FIXME:this doesn't need to happen every update (I think)
-  if _route.getControlledActor() or _player then
-    _view.sector:updateFov(_route.getControlledActor() or _player)
-  else
-    print("oops")
-  end
-
   Draw.allTables()
-
 end
 
 function state:keypressed(key)

--- a/game/gamestates/ready_ability.lua
+++ b/game/gamestates/ready_ability.lua
@@ -51,7 +51,6 @@ end
 
 function state:update(dt)
   if DEBUG then return end
-  MAIN_TIMER:update(dt)
   _quick_toggle = min(_HOLDTIME, _quick_toggle + dt)
   if INPUT.wasActionReleased('ACTION_2') then
     if _quick_toggle < _HOLDTIME then

--- a/game/gamestates/start_menu.lua
+++ b/game/gamestates/start_menu.lua
@@ -84,7 +84,6 @@ function state:resume(from, player_info)
 end
 
 function state:update(dt)
-  MAIN_TIMER:update(dt)
 
   if not _locked then
     if INPUT.wasActionPressed('CONFIRM') then

--- a/game/gamestates/user_turn.lua
+++ b/game/gamestates/user_turn.lua
@@ -227,8 +227,6 @@ function state:update(dt)
     return SWITCHER.push(GS.DEVMODE)
   end
 
-  MAIN_TIMER:update(dt)
-
   if _save_and_quit then return SWITCHER.pop("SAVE_AND_QUIT") end
 
   _view.sector:lookAt(_route.getControlledActor())

--- a/game/infra/profile.lua
+++ b/game/infra/profile.lua
@@ -54,13 +54,6 @@ local function _loadInput()
     local inputmap = DB.loadSetting('controls')
     INPUT.setup(inputmap)
   end
-  -- setup input flush
-  local update = love.update
-  love.update = function(dt)
-    update(dt)
-    if INPUT.wasActionReleased('QUIT') then love.event.quit() end
-    INPUT.flush() -- must be called afterwards
-  end
 end
 
 local function _saveInput()

--- a/game/infra/switcher.lua
+++ b/game/infra/switcher.lua
@@ -11,7 +11,6 @@ local _popped = false
 local _switched = false
 
 function SWITCHER.init()
-  Gamestate.registerEvents()
 end
 
 function SWITCHER.start(to, ...)

--- a/game/main.lua
+++ b/game/main.lua
@@ -98,7 +98,9 @@ function love.load(arg)
 end
 
 function love.update(dt)
+  if INPUT.wasActionReleased('QUIT') then love.event.quit() end
   SWITCHER.update(dt)
+  INPUT.flush() -- must be called afterwards
 end
 
 function love.draw()

--- a/game/main.lua
+++ b/game/main.lua
@@ -97,6 +97,14 @@ function love.load(arg)
   SWITCHER.start(GS.START_MENU) --Jump to the inicial state
 end
 
+function love.update(dt)
+  SWITCHER.update(dt)
+end
+
+function love.draw()
+  SWITCHER.draw()
+end
+
 function love.quit()
   imgui.ShutDown();
   PROFILE.quit()

--- a/game/main.lua
+++ b/game/main.lua
@@ -102,6 +102,7 @@ function love.update(dt)
   if INPUT.wasActionReleased('QUIT') then love.event.quit() end
   SWITCHER.update(dt)
   INPUT.flush() -- must be called afterwards
+  Draw.update(dt)
 end
 
 function love.draw()

--- a/game/main.lua
+++ b/game/main.lua
@@ -98,6 +98,7 @@ function love.load(arg)
 end
 
 function love.update(dt)
+  MAIN_TIMER:update(dt)
   if INPUT.wasActionReleased('QUIT') then love.event.quit() end
   SWITCHER.update(dt)
   INPUT.flush() -- must be called afterwards
@@ -111,3 +112,4 @@ function love.quit()
   imgui.ShutDown();
   PROFILE.quit()
 end
+


### PR DESCRIPTION
All drawables now support update calls. Hump's gamestate manager does not overwrite calls to functions of the `love` table anymore. We now have our own `love.update` that we can use and customize on `main.lua`.

You're welcome.