### PR TITLE
Fix deletion/saving when renaming specs in DB

### DIFF
--- a/game/database/init.lua
+++ b/game/database/init.lua
@@ -264,6 +264,23 @@ function DB.save(container)
   _save(container, basepath)
 end
 
+function DB.renameGroupItem(category, group_name, oldname, newname)
+  local group = _loadGroup(category, group_name)
+  local item = group[oldname]
+  local meta = getmetatable(item)
+  group[newname] = item
+  meta.relpath = meta.relpath:gsub(meta.group, oldname)
+  meta.group = newname
+  DB.save(item)
+  DB.deleteGroupItem(category, group_name, oldname)
+end
+
+function DB.deleteGroupItem(category, group_name, spec_name)
+  local group = _loadGroup(category, group_name)
+  group[spec_name] = DEFS.DELETE
+  DB.refresh(group)
+end
+
 function DB.init()
   local meta = {
     relpath = "database",

--- a/game/database/init.lua
+++ b/game/database/init.lua
@@ -150,7 +150,7 @@ function _listItemsIn(category, group_name)
   return pairs(found)
 end
 
-local function _metaSpec(spec, container, name)
+local function _metaSpec(container, name)
   local path = ("%s/%s"):format(getmetatable(container).relpath, name)
   return {
     is_leaf = true,
@@ -183,13 +183,14 @@ local function _get(self, key)
   if fs.getInfo(filepath, 'file') then
     obj = _loadFile(filepath)
     DB.initSpec(obj, self, meta.group)
-    self[key] = obj
     return obj
   end
 end
 
 function DB.initSpec(spec, container, name)
-  return setmetatable(spec, _metaSpec(spec, container, name))
+  -- inserts a leaf spec into the container
+  container[name] = spec
+  return setmetatable(spec, _metaSpec(container, name))
 end
 
 function DB.subschemaTypes(base)
@@ -266,19 +267,16 @@ end
 
 function DB.renameGroupItem(category, group_name, oldname, newname)
   local group = _loadGroup(category, group_name)
-  local item = group[oldname]
-  local meta = getmetatable(item)
-  group[newname] = item
-  meta.relpath = meta.relpath:gsub(meta.group, oldname)
-  meta.group = newname
-  DB.save(item)
+  local spec = DB.initSpec(group[oldname], group, newname)
+  DB.save(spec)
   DB.deleteGroupItem(category, group_name, oldname)
+  return spec
 end
 
 function DB.deleteGroupItem(category, group_name, spec_name)
   local group = _loadGroup(category, group_name)
   group[spec_name] = DEFS.DELETE
-  DB.refresh(group)
+  return DB.refresh(group)
 end
 
 function DB.init()

--- a/game/debug/view/category_list.lua
+++ b/game/debug/view/category_list.lua
@@ -46,7 +46,8 @@ return function(category_name, group_name, title)
 
   local function rename(specname)
     local oldspecname = list[selected]
-    local spec = DB.renameGroupItem(category_name, group_name, oldspecname, specname)
+    local spec = DB.renameGroupItem(category_name, group_name,
+                                    oldspecname, specname)
     if spec then
       delete()
       newvalue(specname, spec)

--- a/game/debug/view/category_list.lua
+++ b/game/debug/view/category_list.lua
@@ -26,6 +26,7 @@ return function(category_name, group_name, title)
     group[item_name] = DEFS.DELETE
     table.remove(list, selected)
     list.n = list.n - 1
+    DB.refresh(group)
   end
 
   local function newvalue(value, spec)
@@ -51,8 +52,9 @@ return function(category_name, group_name, title)
     meta.relpath = meta.relpath:gsub(meta.group, value)
     meta.group = value
     if spec then
-      delete()
       newvalue(value, spec)
+      DB.save(spec)
+      delete()
     end
   end
 


### PR DESCRIPTION
Renaming/deleting things in DB is now delegated better to DB, and uses its own methods in a smarter way.