### PR TITLE
Hide hand and focus bar outside user turn

### DIFF
--- a/game/draw.lua
+++ b/game/draw.lua
@@ -16,6 +16,7 @@ local draw = {}
 
 --Update every drawable object
 function draw.update(dt)
+  Util.updateSubtype(dt, 'frontend-animator')
   for _,layer in pairs(DRAW_TABLE) do
     for o in pairs(layer) do
       if not o.death and not o.invisible and o.update then

--- a/game/gamestates/card_select.lua
+++ b/game/gamestates/card_select.lua
@@ -48,7 +48,6 @@ function state:enter(_, route, _view)
     _hud_animator:activateHand()
   end
   _actor_view = _view.actor
-  _actor_view.onhandview = true
   _hud_animator:enableCardInfo()
 
   --Make cool animation for cards showing up
@@ -57,8 +56,6 @@ end
 
 function state:leave()
 
-  _actor_view.onhandview = false
-  
   _hud_animator:disableCardInfo()
 
 end

--- a/game/gamestates/card_select.lua
+++ b/game/gamestates/card_select.lua
@@ -5,7 +5,7 @@ local PLAYSFX        = require 'helpers.playsfx'
 
 local state = {}
 
-local _LAG = 1.0 -- seconds
+local _LAG = 2.0 -- seconds
 
 --LOCAL VARIABLES--
 

--- a/game/gamestates/card_select.lua
+++ b/game/gamestates/card_select.lua
@@ -56,7 +56,6 @@ end
 
 function state:leave()
 
-  _hud_animator:disableCardInfo()
 
 end
 

--- a/game/gamestates/card_select.lua
+++ b/game/gamestates/card_select.lua
@@ -31,7 +31,7 @@ local function _cancel()
     chose_a_card = false,
   }
   PLAYSFX 'back-menu'
-  _hud_animator:getHandView():deactivate()
+  _hud_animator:deactivateHand()
   SWITCHER.pop(args)
 end
 

--- a/game/gamestates/play.lua
+++ b/game/gamestates/play.lua
@@ -48,6 +48,8 @@ local function _playTurns(...)
     SWITCHER.switch(GS.START_MENU)
   elseif request == "userTurn" then
     _saveRoute()
+    _view.hand:show()
+    _view.focusbar:show()
     SWITCHER.push(GS.USER_TURN, _route, _view, _alert)
     _alert = false
   elseif request == "changeSector" then
@@ -210,6 +212,8 @@ function state:resume(state, args)
 
   if state == GS.USER_TURN then
     if args == "SAVE_AND_QUIT" then return _activity:saveAndQuit() end
+    _view.hand:hide()
+    _view.focusbar:hide()
     _next_action = args.next_action
   elseif state == GS.ANIMATION then
     _alert = _alert or args

--- a/game/gamestates/play.lua
+++ b/game/gamestates/play.lua
@@ -47,7 +47,6 @@ local function _playTurns(...)
     SWITCHER.switch(GS.START_MENU)
   elseif request == "userTurn" then
     _saveRoute()
-    _view.animator:showLowerHUD()
     SWITCHER.push(GS.USER_TURN, _route, _view, _alert)
     _alert = false
   elseif request == "changeSector" then
@@ -199,7 +198,7 @@ function state:resume(state, args)
 
   if state == GS.USER_TURN then
     if args == "SAVE_AND_QUIT" then return _activity:saveAndQuit() end
-    _view.animator:hideLowerHUD()
+    _view.animator:deactivateState()
     _next_action = args.next_action
   elseif state == GS.ANIMATION then
     _alert = _alert or args

--- a/game/gamestates/user_turn.lua
+++ b/game/gamestates/user_turn.lua
@@ -189,7 +189,6 @@ function state:enter(_, route, view, alert)
   _updateAbilityList()
 
   _view = view
-  _view.hand:reset()
   local ability_idx = 1
   for i, widget in ipairs(_widget_abilities.list) do
     if widget:getId() == _widget_abilities.ready then
@@ -270,7 +269,7 @@ function state:update(dt)
     action_request = _SAVE_QUIT
   end
 
-  if _view.hand:isActive() then
+  if _view.animator:isHandActive() then
     action_request = {DEFS.ACTION.PLAY_CARD, true}
   end
 
@@ -419,18 +418,15 @@ _ACTION[DEFS.ACTION.PLAY_CARD] = function(was_active)
   SWITCHER.push(GS.CARD_SELECT, _route, _view)
   local args = coroutine.yield(_task)
   if args.chose_a_card then
-    if args.action_type == 'play' then
-      PLAYSFX 'ok-menu'
-      if args.card_index == 'draw-hand' then
-        _useAction(DEFS.ACTION.DRAW_NEW_HAND)
-      else
-        if _useAction(DEFS.ACTION.PLAY_CARD,
-                      { card_index = args.card_index }) then
-          Signal.emit("actor_used_card", _route.getControlledActor(), index)
-          local card = _route.getControlledActor():getHandCard(args.card_index)
-          local view = _view.hand.hand[args.card_index]
-          view:playAsArt()
-        end
+    PLAYSFX 'ok-menu'
+    if args.card_index == 'draw-hand' then
+      _useAction(DEFS.ACTION.DRAW_NEW_HAND)
+    else
+      if _useAction(DEFS.ACTION.PLAY_CARD,
+                    { card_index = args.card_index }) then
+        Signal.emit("actor_used_card", _route.getControlledActor(), index)
+        local card = _route.getControlledActor():getHandCard(args.card_index)
+        _view.animator:playCardAsArt(args.card_index)
       end
     end
   end

--- a/game/gamestates/user_turn.lua
+++ b/game/gamestates/user_turn.lua
@@ -203,6 +203,14 @@ function state:enter(_, route, view, alert)
 
   _was_on_menu = false
 
+  if route.getControlledActor():isFocused() then
+    _view.animator:setFocusMode()
+  else
+    _view.animator:setExplorationMode()
+  end
+  _view.animator:activateTurn()
+  _view.animator:disableCardInfo()
+
 end
 
 function state:leave()
@@ -214,6 +222,13 @@ function state:leave()
 end
 
 function state:resume(from, args)
+  if _route.getControlledActor():isFocused() then
+    _view.animator:setFocusMode()
+  else
+    _view.animator:setExplorationMode()
+  end
+  _view.animator:activateTurn()
+  _view.animator:disableCardInfo()
   _view.sector.setCooldownPreview(0)
   _resumeTask(args)
   if INPUT.wasAnyPressed() then
@@ -311,6 +326,7 @@ local function _useAction(action_slot, params)
   params = params or {}
   local param = ACTION.pendingInput(action_slot, controlled_actor, params)
   while param do
+    _view.animator:activateAbility()
     _view.sector:setCooldownPreview(
       ACTION.exhaustionCost(action_slot, controlled_actor, params)
     )

--- a/game/gamestates/user_turn.lua
+++ b/game/gamestates/user_turn.lua
@@ -203,13 +203,7 @@ function state:enter(_, route, view, alert)
 
   _was_on_menu = false
 
-  if route.getControlledActor():isFocused() then
-    _view.animator:setFocusMode()
-  else
-    _view.animator:setExplorationMode()
-  end
   _view.animator:activateTurn()
-  _view.animator:disableCardInfo()
 
 end
 
@@ -222,13 +216,7 @@ function state:leave()
 end
 
 function state:resume(from, args)
-  if _route.getControlledActor():isFocused() then
-    _view.animator:setFocusMode()
-  else
-    _view.animator:setExplorationMode()
-  end
   _view.animator:activateTurn()
-  _view.animator:disableCardInfo()
   _view.sector.setCooldownPreview(0)
   _resumeTask(args)
   if INPUT.wasAnyPressed() then

--- a/game/view/card.lua
+++ b/game/view/card.lua
@@ -3,6 +3,7 @@ local TEXTURE = require 'view.helpers.texture'
 local FONT    = require 'view.helpers.font'
 local DEFS    = require 'view.definitions'
 local COLORS  = require 'domain.definitions.colors'
+local Color   = require 'common.color'
 local round   = require 'common.math' .round
 local vec2    = require 'cpml' .vec2
 
@@ -162,7 +163,7 @@ function CardView:draw()
     cg = cg + shine
     cb = cb + shine
     _title_font:set()
-    g.setColor(COLORS.NEUTRAL)
+    g.setColor(COLORS.NEUTRAL * Color:new{1,1,1,self.alpha})
     g.printf(cardname, x + round((w - namewidth)/2),
              round(y-pd-_title_font:getHeight()),
              namewidth, "center")

--- a/game/view/focusbar.lua
+++ b/game/view/focusbar.lua
@@ -71,7 +71,7 @@ function FocusBar:update(dt)
     self.v_offset = self.v_offset + (1 - self.v_offset) * dt * _OFF_SPD
     if self.v_offset > 0.99 then self.v_offset = 1 end
   else
-    self.v_offset = self.v_offset + (0 - self.v_offset) * dt * _OFF_SPD
+    self.v_offset = self.v_offset + (0 - self.v_offset) * dt * _OFF_SPD * 4
     if self.v_offset < 0.01 then self.v_offset = 0 end
   end
 end
@@ -101,7 +101,7 @@ function FocusBar:draw()
   font:set()
   g.push()
   g.origin()
-  g.translate(0, self.v_offset * 40)
+  g.translate(0, self.v_offset * 60)
   g.translate(self.x - handbar_width/2, _HEIGHT - handbar_height - my)
 
   --Drawing background

--- a/game/view/focusbar.lua
+++ b/game/view/focusbar.lua
@@ -41,11 +41,24 @@ function FocusBar:init(route)
   self.emer_fx_speed = 3.5
   self.emer_fx_v = math.sin(self.emer_fx_alpha)
 
+  -- Hide
+  self.hidden = false
+  self.v_offset = 0
+
   _font = _font or FONT.get(_F_NAME, _F_SIZE)
 
 end
 
+function FocusBar:show()
+  self.hidden = false
+end
+
+function FocusBar:hide()
+  self.hidden = true
+end
+
 function FocusBar:update(dt)
+  local _OFF_SPD = 2
   self.actor = self.route.getControlledActor()
   --update emergency effect
   self.emer_fx_alpha = self.emer_fx_alpha + self.emer_fx_speed*dt
@@ -54,6 +67,13 @@ function FocusBar:update(dt)
     self.emer_fx_alpha = self.emer_fx_alpha - self.emer_fx_max
   end
 
+  if self.hidden then
+    self.v_offset = self.v_offset + (1 - self.v_offset) * dt * _OFF_SPD
+    if self.v_offset > 0.99 then self.v_offset = 1 end
+  else
+    self.v_offset = self.v_offset + (0 - self.v_offset) * dt * _OFF_SPD
+    if self.v_offset < 0.01 then self.v_offset = 0 end
+  end
 end
 
 function FocusBar:draw()
@@ -81,6 +101,7 @@ function FocusBar:draw()
   font:set()
   g.push()
   g.origin()
+  g.translate(0, self.v_offset * 40)
   g.translate(self.x - handbar_width/2, _HEIGHT - handbar_height - my)
 
   --Drawing background

--- a/game/view/hand.lua
+++ b/game/view/hand.lua
@@ -45,6 +45,7 @@ function HandView:init(route)
   self.cardinfo = CardInfo(route)
   self.alpha = 1
   self.hiding = false
+  self.keep_focused_card = false
 
   self:reset()
 
@@ -88,6 +89,10 @@ function HandView:deactivate()
                 'out-back')
 end
 
+function HandView:keepFocusedCard(flag)
+  self.keep_focused_card = flag
+end
+
 function HandView:positionForIndex(i)
   local size = #self.hand + 1
   local card = self.hand[i]
@@ -107,7 +112,6 @@ end
 
 function HandView:show()
   self.hiding = false
-  self.invisible = false
 end
 
 function HandView:update(dt)
@@ -122,11 +126,9 @@ function HandView:update(dt)
       self.alpha = self.alpha + (0 - self.alpha) * dt * _FADE_SPD
     else
       self.alpha = 0
-      self.invisible = true
-      self.hiding = false
     end
-  elseif not self.invisible then
-    self.alpha = self.alpha + (1 - self.alpha) * dt * _FADE_SPD
+  else
+    self.alpha = self.alpha + (1 - self.alpha) * dt * _FADE_SPD * 4
   end
 end
 
@@ -160,7 +162,12 @@ function HandView:draw()
     local card = hand[i]
     local dx = (size-i+1)*step
     card:setFocus(i == self.focus_index)
-    card:setAlpha(self.alpha)
+    if DRAW_TABLE['HUD_FX'][card]
+       or (self.keep_focused_card and i == self.focus_index) then
+      card:setAlpha(1)
+    else
+      card:setAlpha(self.alpha)
+    end
     card:setPosition(x - dx + gap,
                      y - 50 + (0.2+enter*0.4)*(i - (size+1)/2)^2*_GAP)
     card:draw()

--- a/game/view/hand.lua
+++ b/game/view/hand.lua
@@ -47,6 +47,8 @@ function HandView:init(route)
   self.route = route
   self.gap_scale = _GAP_SCALE.MIN
   self.cardinfo = CardInfo(route)
+  self.alpha = 1
+  self.hiding = false
 
   self:reset()
 
@@ -119,12 +121,33 @@ function HandView:positionForIndex(i)
          y - 50 + (0.2+enter*0.4)*(i - (size+1)/2)^2*_GAP
 end
 
+function HandView:hide()
+  self.hiding = true
+end
+
+function HandView:show()
+  self.hiding = false
+  self.invisible = false
+end
+
 function HandView:update(dt)
+  local _FADE_SPD = 2
   self:reset()
   for _,card in ipairs(self.hand) do
     card:update(dt)
   end
   self.cardinfo:update(dt)
+  if self.hiding then
+    if self.alpha > 0.10 then
+      self.alpha = self.alpha + (0 - self.alpha) * dt * _FADE_SPD
+    else
+      self.alpha = 0
+      self.invisible = true
+      self.hiding = false
+    end
+  elseif not self.invisible then
+    self.alpha = self.alpha + (1 - self.alpha) * dt * _FADE_SPD
+  end
 end
 
 function HandView:draw()
@@ -157,6 +180,7 @@ function HandView:draw()
     local card = hand[i]
     local dx = (size-i+1)*step
     card:setFocus(i == self.focus_index)
+    card:setAlpha(self.alpha)
     card:setPosition(x - dx + gap,
                      y - 50 + (0.2+enter*0.4)*(i - (size+1)/2)^2*_GAP)
     card:draw()

--- a/game/view/hand.lua
+++ b/game/view/hand.lua
@@ -17,9 +17,6 @@ local _F_SIZE = 24 --Font size
 local _GAP = 20
 local _GAP_SCALE = { MIN = -0.5, MAX = 1 }
 local _BG = {12/256, 12/256, 12/256, 1}
-local _ACTION_TYPES = {
-  'play',
-}
 local _FOCUS_ICON = {
   -6, 0, 0, -9, 6, 0, 0, 9
 }
@@ -41,7 +38,6 @@ function HandView:init(route)
   _WIDTH, _HEIGHT = love.graphics.getDimensions()
 
   self.focus_index = -1 --What card is focused. -1 if none
-  self.action_type = -1
   self.x, self.y = (3*_WIDTH/4)/2, _HEIGHT - 50
   self.initial_x, self.initial_y = self.x, self.y
   self.route = route
@@ -68,27 +64,12 @@ function HandView:moveFocus(dir)
   end
 end
 
-function HandView:getActionType()
-  return _ACTION_TYPES[self.action_type]
-end
-
-function HandView:changeActionType(dir)
-  if dir == 'UP' then
-    self.action_type = (self.action_type - 2) % #_ACTION_TYPES + 1
-  elseif dir == 'DOWN' then
-    self.action_type = self.action_type % #_ACTION_TYPES + 1
-  else
-    error(("Unknown dir %s"):format(dir))
-  end
-end
-
 function HandView:isActive()
   return self.focus_index > 0
 end
 
 function HandView:activate()
   self.focus_index = 1
-  self.action_type = 1
   self:removeTimer("start", MAIN_TIMER)
   self:removeTimer("end", MAIN_TIMER)
   self:addTimer("start", MAIN_TIMER, "tween", 0.2, self,
@@ -98,7 +79,6 @@ end
 
 function HandView:deactivate()
   self.focus_index = -1
-  self.action_type = -1
 
   self:removeTimer("start", MAIN_TIMER)
   self:removeTimer("end", MAIN_TIMER)
@@ -165,7 +145,7 @@ function HandView:draw()
 
   -- draw action type
   _font.set()
-  local colorname = (self:getActionType() or "BACKGROUND"):upper()
+  local colorname = "BACKGROUND"
   local poly = {
     -20, _HEIGHT/2,
     self.x + boxwidth, _HEIGHT/2,

--- a/game/view/hud_animator.lua
+++ b/game/view/hud_animator.lua
@@ -1,0 +1,94 @@
+
+local HandView    = require 'view.hand'
+local FocusBar    = require 'view.focusbar'
+
+local _INFO_LAG = 2.0 -- seconds
+
+local HUDAnimator = Class{
+  __includes = { ELEMENT }
+}
+
+function HUDAnimator:init(route)
+
+  ELEMENT.init(self)
+
+  self.route = route
+
+  -- Hand view
+  self.handview = HandView(route)
+  self.handview:addElement("HUD_BG", nil, "hand_view")
+  Signal.register(
+    "actor_draw",
+    function(actor, card)
+      self.handview:addCard(actor,card)
+    end
+  )
+
+  -- Card info
+  self.info_lag = false
+
+  -- Focus bar
+  self.focusbar = FocusBar(route)
+  self.focusbar:addElement("HUD")
+
+end
+
+function HUDAnimator:getHandView()
+  return self.handview
+end
+
+function HUDAnimator:hideLowerHUD()
+  self.handview:hide()
+  self.focusbar:hide()
+end
+
+function HUDAnimator:showLowerHUD()
+  self.handview:show()
+  self.focusbar:show()
+end
+
+function HUDAnimator:disableCardInfo()
+  self.handview.cardinfo:hide()
+  self.info_lag = false
+end
+
+function HUDAnimator:enableCardInfo()
+  self.info_lag = 0
+end
+
+function HUDAnimator:isHandActive()
+  return self.handview:isActive()
+end
+
+function HUDAnimator:activateHand()
+  self.handview:activate()
+end
+
+function HUDAnimator:playCardAsArt(index)
+  local view = self.handview.hand[index]
+  view:playAsArt()
+end
+
+function HUDAnimator:moveHandFocus(dir)
+  self.handview:moveFocus(dir)
+  if self.info_lag then
+    self.info_lag = 0
+    self.handview.cardinfo:hide()
+  end
+end
+
+function HUDAnimator:update(dt)
+
+  -- If card info is enabled
+  if self.info_lag then
+    self.info_lag = math.min(_INFO_LAG, self.info_lag + dt)
+
+    if self.info_lag >= _INFO_LAG and not self.handview.cardinfo:isVisible() then
+      self.handview.cardinfo:show()
+    end
+  end
+
+end
+
+return HUDAnimator
+

--- a/game/view/hud_animator.lua
+++ b/game/view/hud_animator.lua
@@ -50,23 +50,27 @@ function HUDAnimator:activateHand()
   self.handview:activate()
 end
 
+function HUDAnimator:deactivateHand()
+  self.handview:deactivate()
+end
+
 function HUDAnimator:activateAbility()
   self.handview:keepFocusedCard(true)
   self.handview:hide()
 end
 
 function HUDAnimator:activateTurn()
-  if self.mode == 'focus' then
+  if self.route.getControlledActor():isFocused() then
     self.focusbar:show()
-    if self.handview:isActive() then
-      self.handview:show()
-    end
-  elseif self.mode == 'exploration' then
+  else
     self.focusbar:hide()
-    if not self.handview:isActive() then
-      self.handview:hide()
-    end
   end
+  if self.handview:isActive() then
+    self.handview:show()
+  else
+    self.handview:hide()
+  end
+  self:disableCardInfo()
 end
 
 function HUDAnimator:deactivateState()
@@ -117,7 +121,8 @@ function HUDAnimator:playCardAsArt(index)
     wait(0.2)
     ann:interrupt()
     while ann:isBusy() do wait(1) end
-    ann:announce(cardview.card:getName(), cardview, Util.findId('backbuffer_view'))
+    ann:announce(cardview.card:getName(), cardview,
+                 Util.findId('backbuffer_view'))
     cardview:flashFor(0.5)
     wait(0.5)
     ann:unlock()
@@ -139,7 +144,8 @@ function HUDAnimator:update(dt)
   if self.info_lag then
     self.info_lag = math.min(_INFO_LAG, self.info_lag + dt)
 
-    if self.info_lag >= _INFO_LAG and not self.handview.cardinfo:isVisible() then
+    if self.info_lag >= _INFO_LAG
+       and not self.handview.cardinfo:isVisible() then
       self.handview.cardinfo:show()
     end
   end


### PR DESCRIPTION
Close #892 

However, the hand and focus bar now bounce around when you move. I tried smoothing the effect to make it less uncomfortable, but is it enough?

For what it's worth, it's now very clear when you can act again =)