### PR TITLE
Integrate a promise-like "Deferred" to task yielding

### DIFF
--- a/game/common/activity.lua
+++ b/game/common/activity.lua
@@ -48,8 +48,11 @@ function Task:instance (obj, func, ...)
     return result
   end
 
-  function yield()
-    return coroutine.yield(task)
+  function yield(deferred, ...)
+    if deferred and deferred.andThen then
+      deferred:andThen(resume)
+    end
+    return coroutine.yield(deferred, ...)
   end
 
   function __operator:newindex()
@@ -72,7 +75,7 @@ function Activity:instance(obj)
 
   function __operator:index(name)
     local newtask = Task(_funcs[name])
-    return function (_, ...) newtask.resume(...) end
+    return function (_, ...) return newtask.resume(...) end
   end
 
 end

--- a/game/common/deferred.lua
+++ b/game/common/deferred.lua
@@ -1,0 +1,18 @@
+
+local Deferred = require 'lux.prototype' :new{
+  callback = false
+}
+
+function Deferred:andThen(callback)
+  self.callback = callback
+end
+
+function Deferred:trigger(...)
+  if self.callback then
+    self.callback(...)
+    self.callback = false
+  end
+end
+
+return Deferred
+

--- a/game/view/announcement.lua
+++ b/game/view/announcement.lua
@@ -35,19 +35,15 @@ end
 function _activity:announce(ann)
   ann.add:snap(1)
   ann.flash:snap(0)
-  ann.flash:set(_FLASH_TIME)
-  self.yield(ann.flash:defer(self.resume, true))
+  self.yield(ann.flash:set(_FLASH_TIME))
 
-  ann.add:set(0)
-  self.yield(ann.add:defer(self.resume, true))
+  self.yield(ann.add:set(0))
   
   ann.cooldown:snap(2)
-  ann.cooldown:set(0)
-  self.yield(ann.cooldown:defer(self.resume, true))
+  self.yield(ann.cooldown:set(0))
 
   ann.add:set(1)
-  ann.flash:set(0)
-  self.yield(ann.flash:defer(self.resume, true))
+  self.yield(ann.flash:set(0))
 
   ann.text = false
   ann.invisible = true
@@ -63,7 +59,7 @@ function Announcement:announce(text)
   self.pos.y = 160
   self.invisible = false
   self.locked = false
-  _activity:announce(self)
+  return _activity:announce(self)
 end
 
 function Announcement:getPoint()

--- a/game/view/helpers/tweenvalue.lua
+++ b/game/view/helpers/tweenvalue.lua
@@ -1,4 +1,6 @@
 
+local Deferred = require 'common.deferred'
+
 local TweenValue = Class {
   __includes = { ELEMENT }
 }
@@ -27,8 +29,7 @@ function TweenValue:init(value, interpolator_name, ...)
   self.value = value
   self.target = value
   self.interpolator = _interpolators[interpolator_name or 'linear'](...)
-  self.callback = false
-  self.callback_once = false
+  self.deferred = false
   self:setSubtype('frontend-hud')
 end
 
@@ -40,18 +41,17 @@ end
 function TweenValue:checkCallback()
   if math.abs(self.value - self.target) <= 0.01 then
     self.value = self.target
-    if self.callback then
-      self.callback()
-      if self.callback_once then
-        self.callback = false
-        self.callback_once = false
-      end
+    if self.deferred then
+      self.deferred:trigger()
+      self.deferred = false
     end
   end
 end
 
 function TweenValue:set(target)
   self.target = target
+  self.deferred = Deferred:new{}
+  return self.deferred
 end
 
 function TweenValue:snap(value)


### PR DESCRIPTION
The `yield` method for activity tasks now accepts `Deffered` objects,
and assumes they take a callback which is called at a later time. The
`yield` method then fills the callback with `resume`.

See `view/announcement.lua` for an example.