### PR TITLE
Calling destroyAll( ) method from STEAMING on love update

### DIFF
--- a/game/gamestates/animation.lua
+++ b/game/gamestates/animation.lua
@@ -42,8 +42,6 @@ function state:update(dt)
     _sector_view:updateVFX(dt)
   end
 
-  Util.destroyAll()
-
 end
 
 function state:draw()

--- a/game/gamestates/hud_animation.lua
+++ b/game/gamestates/hud_animation.lua
@@ -38,7 +38,6 @@ function state:update(dt)
   if not _action_hud or not _action_hud:isAnimating() then
     SWITCHER.pop()
   end
-  Util.destroyAll()
 
 end
 

--- a/game/gamestates/play.lua
+++ b/game/gamestates/play.lua
@@ -192,8 +192,6 @@ function state:update(dt)
     _view.sector:lookAt(_route.getControlledActor() or _player)
   end
 
-  Util.destroyAll()
-
 end
 
 function state:resume(state, args)

--- a/game/gamestates/user_turn.lua
+++ b/game/gamestates/user_turn.lua
@@ -163,8 +163,6 @@ function state:update(dt)
     _startTask(action_request, param)
   end
 
-  Util.destroyAll()
-
 end
 
 function state:draw()

--- a/game/main.lua
+++ b/game/main.lua
@@ -16,6 +16,7 @@ cpml      = require 'cpml'
 local Res     = require "steaming.res_manager"
 local Setup   = require "setup"
 local Draw    = require "draw"
+local Util    = require "steaming.util"
 
 -- GAMESTATES
 GS = require 'gamestates'
@@ -78,6 +79,7 @@ function love.update(dt)
   SWITCHER.update(dt)
   INPUT.flush() -- must be called afterwards
   Draw.update(dt)
+  Util.destroyAll()
 end
 
 function love.draw()


### PR DESCRIPTION
Removed from other updates. Kept when called leaving states, since we still might want to call it sooner 
in some cases.

Closes #868 