### PR TITLE
Fixed crash when using some attacks

### DIFF
--- a/game/database/resources/sfx/attack-hit.json
+++ b/game/database/resources/sfx/attack-hit.json
@@ -1,3 +1,4 @@
 {
-  "filename":"player_attack.wav"
+  "filename":"player_attack.wav",
+  "polyphony":3
 }

--- a/game/resources/sfx.lua
+++ b/game/resources/sfx.lua
@@ -5,7 +5,6 @@ local Sfx = {}
 local Source = Class({})
 
 function Source:init(path, polyphony)
-    print(path, polyphony, "here")
     assert(polyphony > 0, "Not a valid polyphony value")
     self.buffer_size = polyphony
 

--- a/game/resources/sfx.lua
+++ b/game/resources/sfx.lua
@@ -5,6 +5,7 @@ local Sfx = {}
 local Source = Class({})
 
 function Source:init(path, polyphony)
+    print(path, polyphony, "here")
     assert(polyphony > 0, "Not a valid polyphony value")
     self.buffer_size = polyphony
 


### PR DESCRIPTION
The problem was the sfx attack-hit didn't have an polyphonic value. This would make the game crash when using some cards such as 'trained strike'.

Closes #974 