### PR TITLE
Fix holdbar locks + cleaned the code

### DIFF
--- a/game/database/domains/card/rush.json
+++ b/game/database/domains/card/rush.json
@@ -59,7 +59,7 @@
     "cost":20
   },
   "attr":"COR",
-  "desc":"It's rush hour.And I'm not talking about kong-fu.",
+  "desc":"It's rush hour.And I'm not talking about kung-fu.",
   "icon":"card-rush",
   "name":"Rush",
   "pp":10,

--- a/game/gamestates/open_pack.lua
+++ b/game/gamestates/open_pack.lua
@@ -59,8 +59,6 @@ local function _consumeCards(consumed)
 end
 
 function state:enter(from, route, packlist)
-  local hud = Util.findId("action-hud")
-  if hud then hud:lockHoldbar() end
   _status = "choosing_pack"
   _route = route
   _pack = nil
@@ -73,8 +71,6 @@ function state:enter(from, route, packlist)
 end
 
 function state:leave()
-  local hud = Util.findId("action-hud")
-  if hud then hud:lockHoldbar() end
   _leave = false
   _card_list_view:close()
   _card_list_view = nil

--- a/game/gamestates/open_pack.lua
+++ b/game/gamestates/open_pack.lua
@@ -1,4 +1,3 @@
-
 local INPUT        = require 'input'
 local DIRECTIONALS = require 'infra.dir'
 local DEFS         = require 'domain.definitions'
@@ -6,6 +5,7 @@ local PLAYSFX      = require 'helpers.playsfx'
 local PackView     = require 'view.packlist'
 local CardView     = require 'view.consumelist'
 local Draw         = require "draw"
+local Util         = require "steaming.util"
 
 local state = {}
 
@@ -59,6 +59,8 @@ local function _consumeCards(consumed)
 end
 
 function state:enter(from, route, packlist)
+  local hud = Util.findId("action-hud")
+  if hud then hud:lockHoldbar() end
   _status = "choosing_pack"
   _route = route
   _pack = nil
@@ -71,6 +73,8 @@ function state:enter(from, route, packlist)
 end
 
 function state:leave()
+  local hud = Util.findId("action-hud")
+  if hud then hud:lockHoldbar() end
   _leave = false
   _card_list_view:close()
   _card_list_view = nil

--- a/game/gamestates/open_pack.lua
+++ b/game/gamestates/open_pack.lua
@@ -5,7 +5,6 @@ local PLAYSFX      = require 'helpers.playsfx'
 local PackView     = require 'view.packlist'
 local CardView     = require 'view.consumelist'
 local Draw         = require "draw"
-local Util         = require "steaming.util"
 
 local state = {}
 

--- a/game/gamestates/pick_target.lua
+++ b/game/gamestates/pick_target.lua
@@ -5,7 +5,6 @@ local DIR          = require 'domain.definitions.dir'
 local PLAYSFX      = require 'helpers.playsfx'
 local vec2         = require 'cpml' .vec2
 local Draw         = require "draw"
-local Util         = require "steaming.util"
 
 --STATE--
 local state = {}
@@ -23,7 +22,6 @@ local _confirm
 local _cancel
 
 --STATE FUNCTIONS--
-
 function state:enter(_, sector_view, target_opt)
   _sector_view = sector_view
   local i, j = unpack(target_opt.pos)

--- a/game/gamestates/pick_target.lua
+++ b/game/gamestates/pick_target.lua
@@ -5,6 +5,7 @@ local DIR          = require 'domain.definitions.dir'
 local PLAYSFX      = require 'helpers.playsfx'
 local vec2         = require 'cpml' .vec2
 local Draw         = require "draw"
+local Util         = require "steaming.util"
 
 --STATE--
 local state = {}
@@ -24,7 +25,8 @@ local _cancel
 --STATE FUNCTIONS--
 
 function state:enter(_, sector_view, target_opt)
-
+  local hud = Util.findId("action-hud")
+  if hud then hud:lockHoldbar() end
   _sector_view = sector_view
   local i, j = unpack(target_opt.pos)
   _sector_view:newCursor(i, j, target_opt.aoe_hint, target_opt.validator,
@@ -55,6 +57,8 @@ function state:enter(_, sector_view, target_opt)
 end
 
 function state:leave()
+  local hud = Util.findId("action-hud")
+  if hud then hud:unlockHoldbar() end
   _moveCursor = nil
   _confirm = nil
   _cancel = nil

--- a/game/gamestates/pick_target.lua
+++ b/game/gamestates/pick_target.lua
@@ -25,8 +25,6 @@ local _cancel
 --STATE FUNCTIONS--
 
 function state:enter(_, sector_view, target_opt)
-  local hud = Util.findId("action-hud")
-  if hud then hud:lockHoldbar() end
   _sector_view = sector_view
   local i, j = unpack(target_opt.pos)
   _sector_view:newCursor(i, j, target_opt.aoe_hint, target_opt.validator,
@@ -57,8 +55,6 @@ function state:enter(_, sector_view, target_opt)
 end
 
 function state:leave()
-  local hud = Util.findId("action-hud")
-  if hud then hud:unlockHoldbar() end
   _moveCursor = nil
   _confirm = nil
   _cancel = nil

--- a/game/gamestates/play.lua
+++ b/game/gamestates/play.lua
@@ -72,6 +72,7 @@ local function _initFrontend()
 
   _view.action_hud = ActionHUD(_route)
   _view.action_hud:setSubtype('frontend-hud')
+  _view.action_hud:setId('action-hud')
 
   -- Buffer views
   _view.frontbuffer = BufferView.newFrontBufferView(_route)

--- a/game/gamestates/play.lua
+++ b/game/gamestates/play.lua
@@ -72,7 +72,6 @@ local function _initFrontend()
 
   _view.action_hud = ActionHUD(_route)
   _view.action_hud:setSubtype('frontend-hud')
-  _view.action_hud:setId('action-hud')
 
   -- Buffer views
   _view.frontbuffer = BufferView.newFrontBufferView(_route)

--- a/game/view/action_hud.lua
+++ b/game/view/action_hud.lua
@@ -73,7 +73,6 @@ function ActionHUD:init(route)
   self.holdbar:lock()
   self.holdbar:register("HUD")
   self.justheld = false
-  self.holdbar_is_unlockable = true
 
   -- Long walk variables
   self.alert = false
@@ -333,8 +332,7 @@ end
 
 local function _endInspect(self)
   self.inspecting = false
-  if not self.justheld and self.holdbar:isLocked()
-                       and self.holdbar_is_unlockable then
+  if not self.justheld and self.holdbar:isLocked() then
     self.holdbar:unlock()
   end
 end
@@ -343,11 +341,9 @@ function ActionHUD:update(dt)
   --Checks if player can draw a new hand
   local player = self.route.getControlledActor()
   if player:getPP() < player:getBody():getConsumption() and
-     not self.holdbar:isLocked() then
+     not self.holdbar:isLocked()
+  then
     self.holdbar:lock()
-    self.holdbar_is_unlockable = false
-  elseif player:getPP() >= player:getBody():getConsumption() then
-    self.holdbar_is_unlockable = true
   end
 
   -- Input alerts long walk

--- a/game/view/action_hud.lua
+++ b/game/view/action_hud.lua
@@ -231,6 +231,14 @@ function ActionHUD:sendAlert(flag)
   self.alert = self.alert or flag
 end
 
+function ActionHUD:lockHoldbar()
+  self.holdbar:lock()
+end
+
+function ActionHUD:unlockHoldbar()
+  self.holdbar:unlock()
+end
+
 --[[ INPUT methods ]]--
 
 function ActionHUD:wasAnyPressed()
@@ -369,15 +377,21 @@ function ActionHUD:update(dt)
         if not self.handview:isActive() then
           self.handview:activate()
         end
-        _endInspect(self)
+        if self.inspecting then
+          _endInspect(self)
+        end
       end
     else
-      _endInspect(self)
+      if self.inspecting then
+        _endInspect(self)
+      end
       self.focusbar:hide()
       _disableHUDElements(self)
     end
   else
-    _endInspect(self)
+    if self.inspecting then
+      _endInspect(self)
+    end
     _disableHUDElements(self)
   end
 

--- a/game/view/packlist.lua
+++ b/game/view/packlist.lua
@@ -122,7 +122,7 @@ function View:selectPrev(n)
   self.holdbar:reset()
 end
 
-function View:selectNext()
+function View:selectNext(n)
   if self:isLocked() then return end
   n = n or 1
   self.selection = _next_circular(self.selection, #self.pack_list, n)


### PR DESCRIPTION
This PR does the following:

- Holdbar is locked on gamestates it should be (such as when choosing targets or opening packs)
- Fixed a typo on 'rush' card flavor text
- Fixed global variable on packlist view, that was supposed to be local
- Cleaned some unnecessary code on action hud due to this refactoring

Closes #946 