### PR TITLE
Map chunk editor

### DIFF
--- a/game/database/domains/sector/initial.json
+++ b/game/database/domains/sector/initial.json
@@ -5,5 +5,11 @@
     "mw":0,
     "tileset":"demo",
     "w":0
-  }
+  },
+  "tilemap":{
+    "data":[1,1,1,1,1,1,1,1,1],
+    "height":3,
+    "width":3
+  },
+  "theme":false
 }

--- a/game/database/domains/sector/initial.json
+++ b/game/database/domains/sector/initial.json
@@ -6,10 +6,5 @@
     "tileset":"demo",
     "w":0
   },
-  "tilemap":{
-    "data":[1,1,1,1,1,1,1,1,1],
-    "height":3,
-    "width":3
-  },
   "theme":false
 }

--- a/game/database/schema/sector.lua
+++ b/game/database/schema/sector.lua
@@ -1,9 +1,6 @@
 
 return  {
   { id = 'theme', name = "Theme", type = 'enum', options = 'domains.theme' },
-  { id = 'tilemap', name = "Seed", type = 'tilemap',
-    minwidth = 3, minheight = 3, maxwidth = 9, maxheight = 9,
-    palette = {' ', '.', '#'} },
   { id = 'bootstrap', name = "Base Settings", type = 'section',
     schema = 'transformers.bootstrap', required = true },
   { id = 'holes', name = "Holes Settings", type = 'section',

--- a/game/database/schema/sector.lua
+++ b/game/database/schema/sector.lua
@@ -1,6 +1,8 @@
 
 return  {
   { id = 'theme', name = "Theme", type = 'enum', options = 'domains.theme' },
+  { id = 'tilemap', name = "Seed", type = 'tilemap',
+    minwidth = 3, minheight = 3},
   { id = 'bootstrap', name = "Base Settings", type = 'section',
     schema = 'transformers.bootstrap', required = true },
   { id = 'holes', name = "Holes Settings", type = 'section',

--- a/game/database/schema/sector.lua
+++ b/game/database/schema/sector.lua
@@ -2,7 +2,8 @@
 return  {
   { id = 'theme', name = "Theme", type = 'enum', options = 'domains.theme' },
   { id = 'tilemap', name = "Seed", type = 'tilemap',
-    minwidth = 3, minheight = 3},
+    minwidth = 3, minheight = 3, maxwidth = 9, maxheight = 9,
+    palette = {' ', '.', '#'} },
   { id = 'bootstrap', name = "Base Settings", type = 'section',
     schema = 'transformers.bootstrap', required = true },
   { id = 'holes', name = "Holes Settings", type = 'section',

--- a/game/devmode/view/input/tilemap.lua
+++ b/game/devmode/view/input/tilemap.lua
@@ -33,27 +33,28 @@ function TileMapEditor:instance(obj, _elementspec, _fieldschema)
     data = {}
   }
 
-  local function _clampDimensions()
-    _tilemap.width = max(min(_tilemap.width, _maxwidth), _minwidth)
-    _tilemap.height = max(min(_tilemap.height, _maxheight), _minheight)
+  local function _clampDimensions(width, height)
+    return max(min(width, _maxwidth), _minwidth),
+           max(min(height, _maxheight), _minheight)
   end
 
   local function _resize(newwidth, newheight)
-    _tilemap.width = newwidth
-    _tilemap.height = newheight
-    _clampDimensions()
+    newwidth, newheight = _clampDimensions(newwidth, newheight)
     local newdata = {}
     for i = 1, newheight do
       for j = 1, newwidth do
         local tile = 1
-        if i <= _tilemap.height or j <= _tilemap.width then
+        if i <= _tilemap.height and j <= _tilemap.width then
           local idx = (i-1) * _tilemap.width + j
           tile = _tilemap.data[idx] or tile
         end
-        newdata[(i-1) * newwidth + j] = tile
+        local idx = (i-1) * newwidth + j
+        newdata[idx] = tile
       end
     end
     _tilemap.data = newdata
+    _tilemap.width = newwidth
+    _tilemap.height = newheight
   end
 
   _resize(_tilemap.width, _tilemap.height)
@@ -74,11 +75,12 @@ function TileMapEditor:instance(obj, _elementspec, _fieldschema)
           local idx = (i-1) * _tilemap.width + j
           local tile = _tilemap.data[idx]
           local glyph = _palette[tile]
+          IMGUI.PushID(("-%d:%d"):format(i, j))
           if IMGUI.SmallButton(glyph) then
             tile = (tile % #_palette) + 1
             _tilemap.data[idx] = tile
-            print(tile)
           end
+          IMGUI.PopID()
           if j < _tilemap.width then
             IMGUI.SameLine()
           end

--- a/game/devmode/view/input/tilemap.lua
+++ b/game/devmode/view/input/tilemap.lua
@@ -3,13 +3,12 @@ local IMGUI = require 'imgui'
 local class = require 'lux.class'
 
 local setfenv = setfenv
-local ipairs = ipairs
 local print = print
 local max, min = math.max, math.min
 
 local TileMapEditor = class:new()
 
-function TileMapEditor:instance(obj, _elementspec, _fieldschema)
+function TileMapEditor.instance(_, obj, _elementspec, _fieldschema)
 
   setfenv(1, obj)
 
@@ -24,7 +23,15 @@ function TileMapEditor:instance(obj, _elementspec, _fieldschema)
     data = ""
   }
 
+  local function _clampDimensions()
+    _tilemap.width = max(min(_tilemap.width, _maxwidth), _minwidth)
+    _tilemap.height = max(min(_tilemap.height, _maxheight), _minheight)
+  end
+
   local function _resize(newwidth, newheight)
+    _tilemap.width = newwidth
+    _tilemap.height = newheight
+    _clampDimensions()
     local newdata = ""
     for i = 1, newheight do
       for j = 1, newwidth do
@@ -72,11 +79,6 @@ function TileMapEditor:instance(obj, _elementspec, _fieldschema)
   end
 
   _resize(_tilemap.width, _tilemap.height)
-
-  local function _clampDimensions()
-    _tilemap.width = max(min(_tilemap.width, _maxwidth), _minwidth)
-    _tilemap.height = max(min(_tilemap.height, _maxheight), _minheight)
-  end
 
   _elementspec[_fieldschema.id] = _tilemap
 

--- a/game/devmode/view/input/tilemap.lua
+++ b/game/devmode/view/input/tilemap.lua
@@ -1,0 +1,101 @@
+
+local IMGUI = require 'imgui'
+local class = require 'lux.class'
+
+local setfenv = setfenv
+local ipairs = ipairs
+local print = print
+local max, min = math.max, math.min
+
+local TileMapEditor = class:new()
+
+function TileMapEditor:instance(obj, _elementspec, _fieldschema)
+
+  setfenv(1, obj)
+
+  local _minwidth, _minheight = _fieldschema.minwidth or 1,
+                                _fieldschema.minheight or 1
+  local _maxwidth, _maxheight = _fieldschema.maxwidth or _minwidth,
+                                _fieldschema.maxheight or _minheight
+
+  local _tilemap = _elementspec[_fieldschema.id] or {
+    width = _minwidth,
+    height = _minheight,
+    data = ""
+  }
+
+  local function _resize(newwidth, newheight)
+    local newdata = ""
+    for i = 1, newheight do
+      for j = 1, newwidth do
+        local tile = ''
+        if i <= _tilemap.height or j <= _tilemap.width then
+          local idx = (i-1) * _tilemap.width + j
+          tile = _tilemap.data:sub(idx, idx)
+        end
+        if tile == '' then tile = '.' end
+        newdata = newdata .. tile
+      end
+    end
+    _tilemap.data = newdata
+  end
+
+  local function _toText()
+    local text = ""
+    for i = 1, _tilemap.height do
+      local begin = 1 + (i-1)*_tilemap.width
+      text = text .. _tilemap.data:sub(begin, begin + _tilemap.width-1) .. '\n'
+    end
+    print(text)
+    return text
+  end
+
+  local function _fromText(text)
+    print("apply")
+    local newdata = ""
+    local scan, last = 1, 1
+    print(text)
+    while scan <= #text do
+      local newchar = text:sub(scan, scan)
+      local oldchar = _tilemap.data:sub(last, last)
+      if newchar ~= '\n' then
+        newdata = newdata .. newchar
+        last = last + 1
+        if newchar ~= oldchar then
+          scan = scan + 1
+        end
+      end
+      scan = scan + 1
+    end
+    _tilemap.data = newdata
+    print(_toText())
+  end
+
+  _resize(_tilemap.width, _tilemap.height)
+
+  local function _clampDimensions()
+    _tilemap.width = max(min(_tilemap.width, _maxwidth), _minwidth)
+    _tilemap.height = max(min(_tilemap.height, _maxheight), _minheight)
+  end
+
+  _elementspec[_fieldschema.id] = _tilemap
+
+  function input(gui)
+    IMGUI.PushID(_fieldschema.id)
+    IMGUI.Text(_fieldschema.name)
+    local newwidth, newheight, changed =
+      IMGUI.InputInt2('Dimensions', _tilemap.width, _tilemap.height)
+    if changed then _resize(newwidth, newheight) end
+    local length = (_tilemap.width+1) * _tilemap.height + 2
+    local text, changed = IMGUI.InputTextMultiline("Tilemap", _toText(), length)
+    if changed then _fromText(text) end
+    IMGUI.PopID()
+  end
+
+  function __operator:call(gui)
+    return obj.input(gui)
+  end
+end
+
+return { tilemap = TileMapEditor }
+

--- a/game/devmode/view/input/tilemap.lua
+++ b/game/devmode/view/input/tilemap.lua
@@ -6,9 +6,18 @@ local setfenv = setfenv
 local print = print
 local max, min = math.max, math.min
 
+--- Input editor for tilemap fields.
+--  Schema:
+--  { id = 'internal-identifier', name = "Visible Label",
+--    minwidth = 1, maxwidth = <minwidth>,
+--    minheight = 1, maxheight = <minheight>,
+--    palette = { ' ', '.' } }
+--  Spec:
+--  { width = <minwidth>, height = <minheight>, data = { '.', ... } }
 local TileMapEditor = class:new()
 
-function TileMapEditor.instance(_, obj, _elementspec, _fieldschema)
+-- luacheck: no self
+function TileMapEditor:instance(obj, _elementspec, _fieldschema)
 
   setfenv(1, obj)
 
@@ -16,11 +25,12 @@ function TileMapEditor.instance(_, obj, _elementspec, _fieldschema)
                                 _fieldschema.minheight or 1
   local _maxwidth, _maxheight = _fieldschema.maxwidth or _minwidth,
                                 _fieldschema.maxheight or _minheight
+  local _palette = _fieldschema.palette
 
   local _tilemap = _elementspec[_fieldschema.id] or {
     width = _minwidth,
     height = _minheight,
-    data = ""
+    data = {}
   }
 
   local function _clampDimensions()
@@ -32,65 +42,49 @@ function TileMapEditor.instance(_, obj, _elementspec, _fieldschema)
     _tilemap.width = newwidth
     _tilemap.height = newheight
     _clampDimensions()
-    local newdata = ""
+    local newdata = {}
     for i = 1, newheight do
       for j = 1, newwidth do
-        local tile = ''
+        local tile = 1
         if i <= _tilemap.height or j <= _tilemap.width then
           local idx = (i-1) * _tilemap.width + j
-          tile = _tilemap.data:sub(idx, idx)
+          tile = _tilemap.data[idx] or tile
         end
-        if tile == '' then tile = '.' end
-        newdata = newdata .. tile
+        newdata[(i-1) * newwidth + j] = tile
       end
     end
     _tilemap.data = newdata
-  end
-
-  local function _toText()
-    local text = ""
-    for i = 1, _tilemap.height do
-      local begin = 1 + (i-1)*_tilemap.width
-      text = text .. _tilemap.data:sub(begin, begin + _tilemap.width-1) .. '\n'
-    end
-    print(text)
-    return text
-  end
-
-  local function _fromText(text)
-    print("apply")
-    local newdata = ""
-    local scan, last = 1, 1
-    print(text)
-    while scan <= #text do
-      local newchar = text:sub(scan, scan)
-      local oldchar = _tilemap.data:sub(last, last)
-      if newchar ~= '\n' then
-        newdata = newdata .. newchar
-        last = last + 1
-        if newchar ~= oldchar then
-          scan = scan + 1
-        end
-      end
-      scan = scan + 1
-    end
-    _tilemap.data = newdata
-    print(_toText())
   end
 
   _resize(_tilemap.width, _tilemap.height)
 
   _elementspec[_fieldschema.id] = _tilemap
 
-  function input(gui)
+  function input(_)
     IMGUI.PushID(_fieldschema.id)
     IMGUI.Text(_fieldschema.name)
-    local newwidth, newheight, changed =
-      IMGUI.InputInt2('Dimensions', _tilemap.width, _tilemap.height)
-    if changed then _resize(newwidth, newheight) end
-    local length = (_tilemap.width+1) * _tilemap.height + 2
-    local text, changed = IMGUI.InputTextMultiline("Tilemap", _toText(), length)
-    if changed then _fromText(text) end
+    do -- dimensions editor
+      local newwidth, newheight, changed =
+        IMGUI.InputInt2('Dimensions', _tilemap.width, _tilemap.height)
+      if changed then _resize(newwidth, newheight) end
+    end
+    do -- tiles editor
+      for i = 1, _tilemap.height do
+        for j = 1, _tilemap.width do
+          local idx = (i-1) * _tilemap.width + j
+          local tile = _tilemap.data[idx]
+          local glyph = _palette[tile]
+          if IMGUI.SmallButton(glyph) then
+            tile = (tile % #_palette) + 1
+            _tilemap.data[idx] = tile
+            print(tile)
+          end
+          if j < _tilemap.width then
+            IMGUI.SameLine()
+          end
+        end
+      end
+    end
     IMGUI.PopID()
   end
 


### PR DESCRIPTION
Close #1004 
Depends on #1012 

This PR introduces a new type of input editor for tilemaps. In the field schema, you specify the limits of the map and the palette of possible glyphs. Then you edit from devmode:

![tilemap-editor](https://user-images.githubusercontent.com/645222/56758730-b8bcfc00-676d-11e9-823e-8fbda3cbc223.png)

