### PR TITLE
Fix/1026

### DIFF
--- a/game/gamestates/settings.lua
+++ b/game/gamestates/settings.lua
@@ -92,6 +92,7 @@ function state:leave()
     for field, value in pairs(_original) do
       PROFILE.setPreference(field, value)
     end
+    SoundTrack.get():setVolumeToPreference()
   end
   _view:destroy()
 end

--- a/game/gamestates/settings.lua
+++ b/game/gamestates/settings.lua
@@ -88,7 +88,6 @@ function state:leave()
   -- when you leave, it will either save or restore the changes
   if _save then
     PROFILE.save()
-    PROFILE.init()
   else
     for field, value in pairs(_original) do
       PROFILE.setPreference(field, value)

--- a/game/gamestates/settings.lua
+++ b/game/gamestates/settings.lua
@@ -90,7 +90,7 @@ function state:leave()
     PROFILE.save()
     PROFILE.init()
   else
-    for field, value in ipairs(_original) do
+    for field, value in pairs(_original) do
       PROFILE.setPreference(field, value)
     end
   end


### PR DESCRIPTION
Closes #1026  by deleting a weird PROFILE.init call in that file (that I couldn't understand the purpose or why was it there in the first place).

Also discovered and fixed a bug where cancelling from the setting's state wouldn't restore properties to their original values.