### PR TITLE
Dialogue Boxes have pages + header-only tags

### DIFF
--- a/game/database/domains/body/npc-welcome.json
+++ b/game/database/domains/body/npc-welcome.json
@@ -1,6 +1,6 @@
 {
   "appearance":"corgi",
-  "dialogue":"Welcome to Back[newpage value:2]door Route!",
+  "dialogue":"Welcome to Backdoor Route!",
   "drops":{
     "1":{
       "droprate":100,

--- a/game/database/domains/body/npc-welcome.json
+++ b/game/database/domains/body/npc-welcome.json
@@ -1,6 +1,6 @@
 {
   "appearance":"corgi",
-  "dialogue":"Welcome to Backdoor Route!",
+  "dialogue":"Welcome to Back[newpage value:2]door Route!",
   "drops":{
     "1":{
       "droprate":100,

--- a/game/view/dialoguebox.lua
+++ b/game/view/dialoguebox.lua
@@ -211,7 +211,6 @@ function DialogueBox:init(body, i, j, side)
 
   --Pages attributes
   self.cur_page = 1
-  self.pages = 1
 
   self.deactivating = false
   self.activating = true
@@ -327,11 +326,13 @@ end
 function DialogueBox:getSize()
   local max_x, max_y = 0, 0
   for _, c in ipairs(self.text) do
-    if max_x < c.x + c.width then
-      max_x = c.x + c.width
-    end
-    if max_y < c.y + c.height then
-      max_y = c.y + c.height
+    if c.page == self.cur_page then
+      if max_x < c.x + c.width then
+        max_x = c.x + c.width
+      end
+      if max_y < c.y + c.height then
+        max_y = c.y + c.height
+      end
     end
   end
   local w = math.min(max_x + _TEXT_MARGIN, _MAX_WIDTH)

--- a/game/view/dialoguebox.lua
+++ b/game/view/dialoguebox.lua
@@ -28,7 +28,7 @@ local _TEXT_MARGIN = 5
 --Text objects entrance and exit fx
 local _ENTER_SPEED = 10
 local _ENTER_OFFSET = 3
-local _EXIT_SPEED = 7
+local _EXIT_SPEED = 10
 
 --Different fonts a char can have
 local _CHAR_FONT = {


### PR DESCRIPTION
This PR enables dialogues to have multiple pages using the tag [newpage].

It also enables tags without attributes (such as [endl] for a quick line break, instead of the previously long and awkward [endl value:1].