### PR TITLE
Dialogue boxes now resize smoothly + Fixed small newpage bug

### DIFF
--- a/game/view/dialoguebox.lua
+++ b/game/view/dialoguebox.lua
@@ -556,7 +556,7 @@ function interpretateTag(effect_data, attributes, dialogue_box, parsed_text, cur
       local wait_amount = tonumber(aux_att["wait"])
       local text = effect_data.text
       local effect = _NEWPAGE_EFFECT:format(wait_amount)
-      effect_data.text = text:sub(0, cur_pos) .. effect .. text:sub(cur_pos + 1, -1)
+      effect_data.text = text:sub(0, cur_pos - 1) .. effect .. text:sub(cur_pos, -1)
     else
       err = true
     end

--- a/game/view/dialoguebox.lua
+++ b/game/view/dialoguebox.lua
@@ -233,9 +233,9 @@ function DialogueBox:draw()
   --Scale box to target size
   local tw, th = self:getTargetSize()
   local eps = 1
-  self.w = self.w + (tw - self.w)*_MOVE_SPEED
+  self.w = self.w + (tw - self.w)*_RESIZE_SPEED
   if math.abs(self.w - tw) <= eps then self.w = tw end
-  self.h = self.h + (th - self.h)*_MOVE_SPEED
+  self.h = self.h + (th - self.h)*_RESIZE_SPEED
   if math.abs(self.h - th) <= eps then self.h = th end
 
   --Move box to target position


### PR DESCRIPTION
When changing pages dialogue boxes now change size smoothly.

Also there was a small bug where newpage would cut some characters from the previous page. This PR also fixes this.