### PR TITLE
Fix #879

### DIFF
--- a/game/common/visibility.lua
+++ b/game/common/visibility.lua
@@ -1,3 +1,4 @@
+
 --Function that manipulate an actor's field of view
 local SCHEMATICS = require 'domain.definitions.schematics'
 
@@ -14,10 +15,9 @@ local transformOctant
 local projectTile
 local fullShadow
 
-local funcs = {}
+local VISIBILITY = {}
 
-
-function funcs.purgeFov(sector)
+function VISIBILITY.purgeFov(sector)
   local w, h = sector:getDimensions()
   local fov = {}
   for i = 1, h do
@@ -30,7 +30,7 @@ function funcs.purgeFov(sector)
 end
 
 --- Reset actor field of view based on a given sector
-function funcs.resetFov(fov, sector)
+function VISIBILITY.resetFov(fov, sector)
 
   local w, h = sector:getDimensions()
   for i = 1, h do
@@ -45,8 +45,8 @@ function funcs.resetFov(fov, sector)
 end
 
 --Update actors field of view based on his position in a given sector
-function funcs.updateFov(actor, sector)
-  funcs.resetFov(actor:getFov(sector), sector)
+function VISIBILITY.updateFov(actor, sector)
+  VISIBILITY.resetFov(actor:getFov(sector), sector)
   for octant = 1, 8 do
     updateOctant(actor, sector, octant)
   end
@@ -67,13 +67,15 @@ function updateOctant(actor, sector, octant)
   local row = 0
   while true do
 
-    local d_i, d_j = transformOctant(row, 0, octant)
-    local pos = {actor_i + d_i, actor_j + d_j}
+    do
+      local d_i, d_j = transformOctant(row, 0, octant)
+      local pos = {actor_i + d_i, actor_j + d_j}
 
-    --Check if tile is inside sector
-    if not sector:isInside(pos[1],pos[2]) then break end
-    if row > actor:getFovRange() then
-      full_shadow = true
+      --Check if tile is inside sector
+      if not sector:isInside(pos[1],pos[2]) then break end
+      if row > actor:getFovRange() then
+        full_shadow = true
+      end
     end
 
     for col = 0, row do
@@ -117,24 +119,6 @@ end
 function isShadowLineFull(shadow_line)
     local list = shadow_line.shadow_list
     return (#list == 1 and list[1].start == 0 and list[1].finish == 1)
-end
-
-local MAX = 80
-
-function printShadowLine(shadow_line)
-  local string = {}
-  for i=1,MAX do
-    string[i] = '.'
-  end
-  for _,shadow in ipairs(shadow_line.shadow_list) do
-    local a,b = shadow.start*MAX,shadow.finish*MAX
-    a = math.floor(a + 0.5)
-    b = math.floor(b + 0.5)
-    for i=a,b do
-      string[i] = 'X'
-    end
-  end
-  print(table.concat(string))
 end
 
 --Create a shadow table
@@ -247,4 +231,5 @@ function projectTile(row, col)
   return newShadow(top_left, bottom_right)
 end
 
-return funcs
+return VISIBILITY
+

--- a/game/domain/actor.lua
+++ b/game/domain/actor.lua
@@ -1,4 +1,6 @@
 
+-- luacheck: no self
+
 local GameElement = require 'domain.gameelement'
 local DB          = require 'database'
 local Card        = require 'domain.card'
@@ -7,9 +9,7 @@ local ABILITY     = require 'domain.ability'
 local RANDOM      = require 'common.random'
 local DEFS        = require 'domain.definitions'
 
-local PLACEMENTS  = require 'domain.definitions.placements'
-local PACK        = require 'domain.pack'
-local Visibility  = require 'common.visibility'
+local VISIBILITY  = require 'common.visibility'
 local Util        = require "steaming.util"
 local Class       = require "steaming.extra_libs.hump.class"
 local Signal      = require "steaming.extra_libs.hump.signal"
@@ -329,7 +329,7 @@ end
 
 function Actor:countCardInBuffer(specname)
   local count = 0
-  for i,card in ipairs(self.buffer) do
+  for _,card in ipairs(self.buffer) do
     if card:getSpecName() == specname then
       count = count + 1
     end
@@ -381,7 +381,7 @@ function Actor:addCardToBackbuffer(card)
   table.insert(self.buffer, card)
 end
 
-function Actor:consumeCard(card)
+function Actor:consumeCard(card) -- luacheck: no unused
   --FIXME: add card rarity modifier!
   local cor, arc, ani = self:trainingDitribution()
   local xp = DEFS.CONSUME_EXP
@@ -416,12 +416,11 @@ function Actor:getPrizePackCount()
   return #self.prizes
 end
 
--- Visibility Methods --
+-- VISIBILITY Methods --
 
 function Actor:getVisibleBodies()
   local seen = {}
   local sector = self:getSector()
-  local w, h = sector:getDimensions()
 
   local range = self:getFovRange()
   local pi, pj = self:getPos()
@@ -469,16 +468,16 @@ end
 function Actor:purgeFov(sector)
   local fov = self:getFov(sector)
   if not fov then
-    self.fov[sector:getId()] = Visibility.purgeFov(sector)
+    self.fov[sector:getId()] = VISIBILITY.purgeFov(sector)
   end
 end
 
 function Actor:resetFov(sector)
-  Visibility.resetFov(self:getFov(sector), sector)
+  VISIBILITY.resetFov(self:getFov(sector), sector)
 end
 
 function Actor:updateFov(sector)
-  Visibility.updateFov(self, sector)
+  VISIBILITY.updateFov(self, sector)
 end
 
 function Actor:getFov(sector)
@@ -597,7 +596,7 @@ end
 
 function Actor:getPowerLevel()
   local lvl = 0
-  for attr,value in pairs(self.upgrades) do
+  for _,value in pairs(self.upgrades) do
     lvl = value + lvl
   end
   return lvl

--- a/game/view/sector/tilemap.lua
+++ b/game/view/sector/tilemap.lua
@@ -1,4 +1,6 @@
 
+-- luacheck: globals love
+
 local RES        = require 'resources'
 local CAM        = require 'common.camera'
 local SCHEMATICS = require 'domain.definitions.schematics'
@@ -9,7 +11,6 @@ local _TILE_W = VIEWDEFS.TILE_W
 local _TILE_H = VIEWDEFS.TILE_H
 local _VIEW_W = VIEWDEFS.HALF_W*2 - 2
 local _VIEW_H = VIEWDEFS.HALF_H*2 - 2
-local _SEEN_ABYSS = COLORS.BACKGROUND * COLORS.HALF_VISIBLE
 
 local _FXCODE = [[
 uniform Image mask;
@@ -31,7 +32,6 @@ local _fovmask
 local _tilemask
 
 function TILEMAP.init(sector, tileset)
-  local pixel_texture = RES.loadTexture("pixel")
   local texture = RES.loadTexture(tileset.texture)
   _tile_batch = love.graphics.newSpriteBatch(texture, 512, "stream")
   _tile_offset = tileset.offsets
@@ -44,9 +44,9 @@ function TILEMAP.init(sector, tileset)
     data:mapPixel(
       function (x, y)
         y = y*_TILE_W/_TILE_H
-        local px = math.max(_TILE_W, math.min(2*_TILE_W, x))
-        local py = math.max(_TILE_W, math.min(2*_TILE_W, y))
-        local d = math.sqrt((x - px)^2 + (y - py)^2)/_TILE_W*2
+        local px = math.max(0.5*_TILE_W, math.min(2.5*_TILE_W, x))
+        local py = math.max(0.5*_TILE_W, math.min(2.5*_TILE_W, y))
+        local d = math.sqrt((x - px)^2 + (y - py)^2)/_TILE_W * 2
         local c = math.max(0, (1-d^2))
         return c, c, c, 1
       end
@@ -54,6 +54,21 @@ function TILEMAP.init(sector, tileset)
     _tilemask = love.graphics.newImage(data)
   end
 end
+
+local _SIDES = { { -1, 0 }, { 1, 0 }, { 0, -1 }, { 0, 1 },
+                 { -1, -1 }, { -1, 1 }, { 1, -1 }, { 1, 1 } }
+local function _isBorder(fov, i, j, outside)
+  for _, side in ipairs(_SIDES) do
+    local ti, tj = i + side[1], j + side[2]
+    if fov[ti] and outside(fov[ti][tj]) then
+      return true
+    end
+  end
+  return false
+end
+
+local function NOT_VISIBLE(v) return not v or v == 0 end
+local function UNSEEN(v) return not v end
 
 function TILEMAP.calculateFOVMask(g, fov)
   g.setCanvas(_fovmask)
@@ -69,15 +84,19 @@ function TILEMAP.calculateFOVMask(g, fov)
   for i, j in CAM:tilesInRange() do
     local ti, tj = i+1, j+1 -- logic coordinates
     local x, y = j*_TILE_W, i*_TILE_H
-    local color = COLORS.NEUTRAL
+    local color = COLORS.BLACK
     if fov and fov[ti] then
-      local visibility = fov[ti][tj]
-      if not visibility then
-        color = COLORS.BLACK
-      elseif visibility == 0 then
-        color = COLORS.HALF_VISIBLE
-      else
-        color = COLORS.NEUTRAL
+      local visible = fov[ti][tj]
+      if visible then
+        if visible > 0 then
+          if not _isBorder(fov, ti, tj, NOT_VISIBLE) then
+            color = COLORS.NEUTRAL
+          elseif not _isBorder(fov, ti, tj, UNSEEN) then
+            color = COLORS.HALF_VISIBLE
+          end
+        elseif visible == 0 and not _isBorder(fov, ti, tj, UNSEEN) then
+          color = COLORS.HALF_VISIBLE
+        end
       end
     end
     g.setColor(color)
@@ -89,7 +108,7 @@ function TILEMAP.calculateFOVMask(g, fov)
   return _fovmask
 end
 
-function TILEMAP.drawAbyss(g, fov)
+function TILEMAP.drawAbyss(g)
   g.push()
 
   g.origin()
@@ -125,7 +144,7 @@ function TILEMAP.drawFloor(g)
   _tile_batch:clear()
 end
 
-function TILEMAP.drawWallInLine(g, i, fov)
+function TILEMAP.drawWallInLine(g, i, fov) -- luacheck: no unused
   -- to be implemented in v11.0
 end
 

--- a/game/view/sector/wall.lua
+++ b/game/view/sector/wall.lua
@@ -1,4 +1,6 @@
 
+-- luacheck: globals love
+
 local WALL = {}
 
 local SCHEMATICS  = require 'domain.definitions.schematics'
@@ -9,15 +11,14 @@ local WallMesh    = require 'view.sector.mesh.wall'
 
 local _TILE_W = VIEWDEFS.TILE_W
 local _TILE_H = VIEWDEFS.TILE_H
-local _WALL_H = 80
-local _MARGIN_W = 12
-local _MARGIN_H = 8
+local _MARGIN_W = 0
+local _MARGIN_H = 0
 local _BORDER_W = 8
 local _BORDER_H = 6
 local _GRID_W = 24
 local _GRID_H = 18
 
-local _TOPLEFT = vec2(0,0)
+local _TOPLEFT = vec2(0,0) -- luacheck: no unused
 local _TOPRIGHT = vec2(_TILE_W, 0)
 local _BOTLEFT = vec2(0, _TILE_H)
 local _BOTRIGHT = vec2(_TILE_W, _TILE_H)
@@ -28,7 +29,6 @@ local _BORDER_COLOR  = {43/256, 100/256, 112/256, 1}
 local _TOP_COLOR  = {0.2, 0.2, 0.2, 0.6}
 
 local _W, _H
-local _MAX_VTX = 4096
 
 local _VTX_FORMAT = {
   {'VertexPosition', 'float', 2},
@@ -50,13 +50,7 @@ vec4 position(mat4 transform_projection, vec4 vertex_position) {
 ]]
 local _VTXSHADER
 
-local _mesh
 local _rowmeshes
-local _vertexcount = 0
-
-local function _wallidx(i, j)
-  return (i-1)*_W + j
-end
 
 local function _neighbors(sector, i, j)
   local neighbors = {}
@@ -100,13 +94,12 @@ local _CORNER_VER = _pack{ _rect(_MARGIN_W + _BORDER_W, _GRID_W, 0, _GRID_H) }
 local _CORNER_OUT = _pack{ vec2(_MARGIN_W + _BORDER_W, _GRID_H),
                            vec2(_GRID_W, _MARGIN_H + _BORDER_H),
                            vec2(_GRID_W, _GRID_H) }
-local _CORNER_INN = _pack{ vec2(0, _MARGIN_H + _BORDER_H), 
+local _CORNER_INN = _pack{ vec2(0, _MARGIN_H + _BORDER_H),
                            vec2(_MARGIN_W + _BORDER_W, 0), vec2(0, _GRID_H),
                            vec2(_GRID_W, 0), vec2(_GRID_W, _GRID_H) }
 local _CORNER_ALL = _pack{ _rect(0, _GRID_W, 0, _GRID_H) }
 
 function WALL.load(sector)
-  local count = 0
   _W, _H = sector:getDimensions()
   _rowmeshes = {}
   if not _VTXSHADER then _VTXSHADER = love.graphics.newShader(_VTXCODE) end
@@ -143,7 +136,7 @@ function WALL.load(sector)
         elseif _walled(neighbors, 1, 2) and _empty(neighbors, 2, 1) then
           -- straight up
           wall:addSide(nil, vec2(_MARGIN_W, 0), vec2(_MARGIN_W, _GRID_H),
-                            vec2(_BORDER_W, 0)) 
+                            vec2(_BORDER_W, 0))
           wall:addTop(_TOP_COLOR, _CORNER_VER())
         elseif _empty(neighbors, 2, 1) and _empty(neighbors, 1, 2) then
           -- outer corner
@@ -172,7 +165,7 @@ function WALL.load(sector)
           -- straight up
           wall:addSide(nil, vec2(_TILE_W - _MARGIN_W, 0),
                             vec2(_TILE_W - _MARGIN_W, _GRID_H),
-                            vec2(-_BORDER_W, 0)) 
+                            vec2(-_BORDER_W, 0))
           wall:addTop(_TOP_COLOR, _xform(_TOPRIGHT, -1, 1, _CORNER_VER()))
         elseif _empty(neighbors, 1, 2) and _empty(neighbors, 2, 3) then
           -- outer corner
@@ -204,7 +197,7 @@ function WALL.load(sector)
 
         -- middle
         do
-          wall:addTop(_TOP_COLOR, _rect(_GRID_W, _TILE_W - _GRID_W, _GRID_H, 
+          wall:addTop(_TOP_COLOR, _rect(_GRID_W, _TILE_W - _GRID_W, _GRID_H,
                                         _TILE_H - _GRID_H))
         end
 
@@ -314,10 +307,7 @@ function WALL.load(sector)
       _rowmeshes[i] = false
     end
   end
-  _mesh = love.graphics.newMesh(_MAX_VTX, 'triangles', 'stream')
 end
-
-local _NULL_VTX = {0, 0, 0, 0, 0, 0, 0, 0}
 
 function WALL.drawRow(i, mask)
   local g = love.graphics


### PR DESCRIPTION
Tiles with at least one neighboring "less visible" tile are considered
"less visible" for rendering purposes now. At the same time, the texture
used to paint "light" was adjusted so that these border tiles are
properly covered with light.