### PR TITLE
Remove diagonals for effects range checks

### DIFF
--- a/game/common/tile.lua
+++ b/game/common/tile.lua
@@ -5,8 +5,7 @@ local abs = math.abs
 local max = math.max
 
 function TILE.dist(i1, j1, i2, j2)
-  return max(abs(i1 - i2), abs(j1 - j2))
+  return abs(i1 - i2) + abs(j1 - j2)
 end
 
 return TILE
-

--- a/game/domain/effects/damage_on_area.lua
+++ b/game/domain/effects/damage_on_area.lua
@@ -1,5 +1,6 @@
 
 local RANDOM  = require 'common.random'
+local TILE    = require 'common.tile'
 local ATTR    = require 'domain.definitions.attribute'
 local FX = {}
 
@@ -32,7 +33,8 @@ function FX.process (actor, fieldvalues)
   for i=ci-size+1,ci+size-1 do
     for j=cj-size+1,cj+size-1 do
       local body = sector:getBodyAt(i, j) if body then
-        if not ignore_owner or body ~= actor:getBody() then
+        if (not ignore_owner or body ~= actor:getBody()) and
+            TILE.dist(i,j,ci,cj) <= size - 1 then
           local result = body:takeDamageFrom(amount, actor)
           coroutine.yield('report', {
             type = 'text_rise',

--- a/game/view/sector.lua
+++ b/game/view/sector.lua
@@ -322,7 +322,7 @@ function SectorView:draw()
             local size   = self.cursor.aoe_hint or 1
             local abs    = math.abs
             if size and tile.type == SCHEMATICS.FLOOR
-                    and abs(i+1 - ci) < size and abs(j+1 - cj) < size then
+                    and TILE.dist(i+1, j+1, ci, cj) <= size-1 then
               table.insert(highlights, { x, 0, _TILE_W, _TILE_H,
                                          Color.fromInt {200, 100, 100, 100} })
             end


### PR DESCRIPTION
Depends on #1069 

Should remove all checks for diagonals in effects and ranges (using norm-1 instead of infinity-norm).

This still doesn't close #1060 since still need to change visibility ranges.

Please test