### PR TITLE
Defensive equipment

### DIFF
--- a/game/database/domains/card/impact-vest.json
+++ b/game/database/domains/card/impact-vest.json
@@ -1,20 +1,20 @@
 {
   "attr":"NONE",
+  "cost":5,
   "desc":"",
   "icon":"card-power-suit",
   "name":"Impact Vest",
   "set":"gadgeteer",
-  "cost":5,
   "type-description":"",
   "widget":{
-    "charges":5,
-    "operators":[],
+    "charges":4,
     "equipment":{
-      "active":false,
       "defensive":{
         "defense":1
-      }
+      },
+      "active":false
     },
+    "operators":[],
     "status-tags":[],
     "trigger":false
   },

--- a/game/database/schema/card.lua
+++ b/game/database/schema/card.lua
@@ -1,6 +1,8 @@
 
 local DEFS = require 'domain.definitions'
 
+local _CARDS = 'domains.card'
+
 return {
   { id = 'one_time', name = "Is One Time Usage", type = 'boolean' },
   { id = 'name', name = "Name", type = 'string' },
@@ -58,16 +60,16 @@ return {
             hint = "Happens when trigger is detected" }
         }
       },
-      { id = 'equipment', name = "Equipment", type = 'section',
+      {
+        id = 'equipment', name = "Equipment", type = 'section',
         schema = { { id = 'active', name = "Active", type = 'section',
                      schema = { { id = 'cards', name = "Action Card",
                                   type = 'array',
                                   schema = { { id = 'card', name = 'Card',
                                                type = 'enum',
-                                               options = 'domains.card' } } } } },
-                   { id = 'defensive', name = "Defensive", type = 'section',
-                     schema = { { id = 'defense', name = "Defense",
-                                  type = 'integer', range = { 0, 99 } } } }, } }
+                                               options = _CARDS } } } } },
+                   { id = 'defensive', name = "Defensive", type = 'boolean' } }
+      }
     }
   }
 }

--- a/game/domain/body.lua
+++ b/game/domain/body.lua
@@ -406,13 +406,16 @@ function Body:removeAllArmor()
 end
 
 function Body:takeDamageFrom(amount, source)
-  local absorbed = math.min(amount, self.armor)
-  self.armor = self.armor - absorbed -- should never go negative
-  local dmg = math.max(0, amount - absorbed)
-  self.damage = math.min(self:getMaxHP(), self.damage + dmg)
+  local defeqp = self:getEquipmentAt('wearable')
+  if defeqp then
+    local absorbed = math.min(amount, defeqp:getEquipmentDefense())
+    defeqp:addUsages(1)
+    amount = math.max(0, amount - absorbed)
+  end
+  self.damage = math.min(self:getMaxHP(), self.damage + amount)
   self.killer = source:getId()
   self:triggerWidgets(TRIGGERS.ON_HIT)
-  return { dmg = dmg }
+  return { dmg = amount }
 end
 
 function Body:loseLifeFrom(amount, source)

--- a/game/domain/body.lua
+++ b/game/domain/body.lua
@@ -407,7 +407,7 @@ end
 function Body:takeDamageFrom(amount, source)
   local defeqp = self:getEquipmentAt('wearable')
   if defeqp then
-    local absorbed = math.min(amount, defeqp:getWidgetCharges())
+    local absorbed = math.min(amount, defeqp:getCurrentWidgetCharges())
     defeqp:addUsages(absorbed)
     amount = math.max(0, amount - absorbed)
   end

--- a/game/domain/body.lua
+++ b/game/domain/body.lua
@@ -1,5 +1,4 @@
 
-local RANDOM      = require 'common.random'
 local ABILITY     = require 'domain.ability'
 local TRIGGERS    = require 'domain.definitions.triggers'
 local EQUIPMENTS  = require 'domain.definitions.equipments'
@@ -179,7 +178,7 @@ function Body:getMaxHP()
   return APT.HP(self:getVIT(), self:getRES())
 end
 
-function Body:getConsumption()
+function Body:getConsumption() -- luacheck: no self
   return 1
 end
 
@@ -408,8 +407,8 @@ end
 function Body:takeDamageFrom(amount, source)
   local defeqp = self:getEquipmentAt('wearable')
   if defeqp then
-    local absorbed = math.min(amount, defeqp:getEquipmentDefense())
-    defeqp:addUsages(1)
+    local absorbed = math.min(amount, defeqp:getWidgetCharges())
+    defeqp:addUsages(absorbed)
     amount = math.max(0, amount - absorbed)
   end
   self.damage = math.min(self:getMaxHP(), self.damage + amount)

--- a/game/domain/card.lua
+++ b/game/domain/card.lua
@@ -153,6 +153,10 @@ function Card:eachActiveEquipmentCards()
   return ipairs(self:getSpec('widget').equipment.active.cards)
 end
 
+function Card:getEquipmentDefense()
+  return self:getSpec('widget').equipment.defensive.defense
+end
+
 function Card:resetTicks()
   self.ticks = 0
 end

--- a/game/domain/card.lua
+++ b/game/domain/card.lua
@@ -144,6 +144,10 @@ function Card:getUsages()
   return self.usages
 end
 
+function Card:getCurrentWidgetCharges()
+  return self:getWidgetCharges() - self:getUsages()
+end
+
 function Card:isSpent()
   local max = self:getWidgetCharges()
   return max > 0 and self:getUsages() >= max

--- a/game/view/actorpanel/widgets/slot.lua
+++ b/game/view/actorpanel/widgets/slot.lua
@@ -6,10 +6,7 @@ local TweenValue  = require 'view.helpers.tweenvalue'
 local COLORS      = require 'domain.definitions.colors'
 local RES         = require 'resources'
 local Class       = require "steaming.extra_libs.hump.class"
-local common      = require 'lux.common'
 
-local _MG = 24
-local _PD = 4
 local _DECAY_TIME = 0.5
 
 local Slot = Class({ __includes = { Node } })
@@ -23,6 +20,7 @@ function Slot:init(x, y, icon)
   self.flash = TweenValue(0, 'linear')
   self.flashcolor = COLORS.FLASH_ANNOUNCE
   self.flashtime = 1
+  self.font = FONT.get('Text', 16)
 end
 
 function Slot:setWidget(widget)
@@ -67,6 +65,8 @@ function Slot:render(g)
     g.rectangle("fill", 0, 0, sqsize, sqsize)
     g.setColor(COLORS.BLACK + flashfx * 2)
     g.draw(icon, 0, 0, 0, sqsize/iw, sqsize/ih)
+    self.font:set()
+    g.print(widget:getCurrentWidgetCharges(), 0, 0)
   elseif self.icon then
     g.setColor(COLORS.BLACK)
     local icon = RES.loadTexture(self.icon)


### PR DESCRIPTION
Turns defensive equipments into damage-absorbing widgets.

Damage taken is removed from charges.

Also poorly display the charge count in the widget slot icon.