### PR TITLE
Better discard animation

### DIFF
--- a/game/database/domains/card/sidestep.json
+++ b/game/database/domains/card/sidestep.json
@@ -36,5 +36,5 @@
   "icon":"card-sidestep",
   "name":"Side-step",
   "set":"brawler",
-  "temporary":false
+  "temporary":true
 }

--- a/game/database/domains/card/sidestep.json
+++ b/game/database/domains/card/sidestep.json
@@ -36,5 +36,5 @@
   "icon":"card-sidestep",
   "name":"Side-step",
   "set":"brawler",
-  "temporary":true
+  "temporary":false
 }

--- a/game/database/domains/card/trained-strike.json
+++ b/game/database/domains/card/trained-strike.json
@@ -49,6 +49,7 @@
   "icon":"card-dropkick",
   "name":"Trained Strike",
   "set":"brawler",
+  "temporary":true,
   "type-description":"",
   "one_time":false
 }

--- a/game/database/domains/card/trained-strike.json
+++ b/game/database/domains/card/trained-strike.json
@@ -49,7 +49,7 @@
   "icon":"card-dropkick",
   "name":"Trained Strike",
   "set":"brawler",
-  "temporary":true,
+  "temporary":false,
   "type-description":"",
   "one_time":false
 }

--- a/game/domain/actor.lua
+++ b/game/domain/actor.lua
@@ -573,12 +573,12 @@ function Actor:discardHand()
     local index = self:getHandSize()
     local card = self:removeHandCard(index)
     if not card:isTemporary() then
-      self:addCardToBackbuffer(card)
       coroutine.yield('report', {
         type = 'discard_card',
         actor = self,
         card_index = index
       })
+      self:addCardToBackbuffer(card)
     else
       coroutine.yield('report', {
         type = 'discard_temporary_card',

--- a/game/domain/actor.lua
+++ b/game/domain/actor.lua
@@ -361,7 +361,7 @@ function Actor:drawCard()
     table.insert(self.buffer, DEFS.DONE)
     card = table.remove(self.buffer, 1)
   end
-  table.insert(self.hand, card)
+  table.insert(self.hand, 1, card)
   coroutine.yield('report', {
     type = "draw_card",
     actor = self,

--- a/game/gamestates/animations/discard_card.lua
+++ b/game/gamestates/animations/discard_card.lua
@@ -14,18 +14,22 @@ function ANIM:script(route, view, report)
     local backbuffer = view.backbuffer
     local hand = action_hud.handview
     local cardview = hand.hand[card_index]
-    local finish = vec2(backbuffer:getPosition())
+    local finish = backbuffer:getTopCardPosition()
     hand:removeCard(card_index)
     action_hud:disableCardInfo()
     cardview:setFocus(false)
     cardview:register("HUD")
-    cardview:addTimer("slide", MAIN_TIMER, "tween", 0.5, cardview,
-                      { position = finish }, 'out-cubic',
-                      function () cardview:kill() end)
-    self.wait(delay:set(0.2))
+    cardview:addTimer("slide", MAIN_TIMER, "tween", .5, cardview,
+                      { position = finish }, 'out-cubic')
+    cardview:addTimer("wait", MAIN_TIMER, "after", .3,
+                      function ()
+                        cardview:addTimer("fadeout", MAIN_TIMER, "tween", .3,
+                                          cardview, {alpha = 0}, 'out-cubic',
+                                          function() cardview:kill() end)
+                      end)
+    self.wait(delay:set(0.25))
   end
   delay:kill()
 end
 
 return ANIM
-

--- a/game/gamestates/animations/discard_temporary_card.lua
+++ b/game/gamestates/animations/discard_temporary_card.lua
@@ -10,8 +10,10 @@ function ANIM:script(route, view, report)
     local hand_view = view.action_hud.handview
     local card_index = report.card_index
     local cardview = hand_view.hand[card_index]
-    self.wait(Dissolve(cardview, .5))
+    cardview:setFocus(false)
     hand_view:removeCard(card_index)
+    self.wait(Dissolve(cardview, .5))
+    cardview:kill()
   end
 end
 

--- a/game/gamestates/animations/draw_card.lua
+++ b/game/gamestates/animations/draw_card.lua
@@ -15,7 +15,7 @@ function ANIM:script(route, view, report)
     local hand = action_hud.handview
     hand:addCard(cardview)
     cardview:register("HUD")
-    cardview:setPosition(frontbuffer:getPosition())
+    cardview:setPosition(frontbuffer:getTopCardPosition():unpack())
     action_hud:disableCardInfo()
     self.wait(delay:set(0.2))
     cardview:setDrawTable("HUD_FX")

--- a/game/view/buffer.lua
+++ b/game/view/buffer.lua
@@ -12,7 +12,7 @@ local ELEMENT = require "steaming.classes.primitives.element"
 local _MX = 32
 local _MY = 32
 local _W_OFFSET = 2
-local _H_OFFSET = -1
+local _H_OFFSET = 1
 local _GRADIENT_FILTER = .3
 local _BACKGROUND_ALPHA = .1
 local _MAX_CARDS = 15
@@ -74,14 +74,12 @@ function BufferView:getPosition()
   return self.pos:unpack()
 end
 
-function BufferView:getPoint()
+function BufferView:getTopCardPosition()
   local size = self.amount
   if self.side == 'front' then
-    return self.pos + vec2(size * _W_OFFSET + self.sprite:getWidth()/2,
-                           size * _H_OFFSET + self.sprite:getHeight()/2)
+    return self.pos + vec2(size * _W_OFFSET, size * _H_OFFSET)
   elseif self.side == 'back' then
-    return self.pos + vec2(size * -_W_OFFSET + self.sprite:getWidth()/2,
-                           size * _H_OFFSET + self.sprite:getHeight()/2)
+    return self.pos + vec2(size * -_W_OFFSET, size * _H_OFFSET)
   end
 end
 
@@ -128,7 +126,7 @@ function BufferView:draw()
   for i = 0, finish, step do
     grd = (i == finish) and 1 or _GRADIENT_FILTER
     g.setColor(self.clr[1]*grd, self.clr[2]*grd, self.clr[3]*grd, self.clr[4])
-    self.sprite:draw(i*_W_OFFSET, -step*i*_H_OFFSET)
+    self.sprite:draw(i*_W_OFFSET, step*i*_H_OFFSET)
   end
   --Draw buffer size
   local card_w, card_h = self.sprite:getWidth(), self.sprite:getHeight()
@@ -137,7 +135,7 @@ function BufferView:draw()
   self.font:set()
   g.setColor(self.clr[1]*grd, self.clr[2]*grd, self.clr[3]*grd, self.clr[4])
   g.print(text, finish*_W_OFFSET + card_w/2 - text_w/2,
-                -step*finish*_H_OFFSET + card_h/2 - text_h/2)
+                step*finish*_H_OFFSET + card_h/2 - text_h/2)
 
 
   g.pop()


### PR DESCRIPTION
FIxed offset problem and added some fadeout.

Also fixed a bug where card order wasn't the same between view and domain, causing some visual desyncs.

Tried to add fade-in to draw card animation, but it has some conflict with handview logic to hide cards when it wants to. Decided to leave it to the future.