### PR TITLE
Revised Sage

### DIFF
--- a/game/database/domains/actor/sage.json
+++ b/game/database/domains/actor/sage.json
@@ -6,17 +6,8 @@
   "description":"After years of effort and study, you have\nbecome proficient in the arcane arts passed down\nsince time immemorial. You strongly believe there\nis nothing the power of your magic cannot achieve,\nso long as you have the time to prepare.",
   "extends":"sentient",
   "initial_buffer":[{
-      "amount":1,
-      "card":"heal"
-    },{
-      "amount":1,
-      "card":"fireball"
-    },{
-      "amount":5,
+      "amount":10,
       "card":"firebolt"
-    },{
-      "amount":3,
-      "card":"catalyst"
     }],
   "name":"Sage",
   "signature":"bolting",

--- a/game/database/domains/actor/sage.json
+++ b/game/database/domains/actor/sage.json
@@ -6,11 +6,17 @@
   "description":"After years of effort and study, you have\nbecome proficient in the arcane arts passed down\nsince time immemorial. You strongly believe there\nis nothing the power of your magic cannot achieve,\nso long as you have the time to prepare.",
   "extends":"sentient",
   "initial_buffer":[{
-      "amount":5,
+      "amount":4,
       "card":"firebolt"
     },{
-      "amount":5,
+      "amount":4,
       "card":"concentration"
+    },{
+      "amount":1,
+      "card":"arcane-burst"
+    },{
+      "amount":1,
+      "card":"chained-energy"
     }],
   "name":"Sage",
   "signature":"bolting",

--- a/game/database/domains/actor/sage.json
+++ b/game/database/domains/actor/sage.json
@@ -6,8 +6,11 @@
   "description":"After years of effort and study, you have\nbecome proficient in the arcane arts passed down\nsince time immemorial. You strongly believe there\nis nothing the power of your magic cannot achieve,\nso long as you have the time to prepare.",
   "extends":"sentient",
   "initial_buffer":[{
-      "amount":10,
+      "amount":5,
       "card":"firebolt"
+    },{
+      "amount":5,
+      "card":"concentration"
     }],
   "name":"Sage",
   "signature":"bolting",

--- a/game/database/domains/card/arcane-burst.json
+++ b/game/database/domains/card/arcane-burst.json
@@ -1,0 +1,36 @@
+{
+  "art":{
+    "art_ability":{
+      "effects":[{
+          "attr":"=arc",
+          "base":2,
+          "center":"=self_pos",
+          "ignore_owner":true,
+          "mod":80,
+          "name":"damage_on_area",
+          "size":3,
+          "type":"effect"
+        }],
+      "inputs":[{
+          "aoe-hint":3,
+          "body-only":{
+            "body-type":false
+          },
+          "max-range":0,
+          "name":"choose_target",
+          "output":"self_pos",
+          "type":"input"
+        },{
+          "name":"get_attribute",
+          "output":"arc",
+          "type":"operator",
+          "which":"ARC"
+        }]
+    }
+  },
+  "attr":"ARC",
+  "cost":3,
+  "icon":"card-fireball",
+  "name":"Arcane Burst",
+  "set":"sage"
+}

--- a/game/database/domains/card/chained-energy.json
+++ b/game/database/domains/card/chained-energy.json
@@ -1,0 +1,21 @@
+{
+  "art":{
+    "art_ability":{
+      "effects":[{
+          "amount":2,
+          "name":"gain_focus",
+          "type":"effect"
+        },{
+          "amount":1,
+          "name":"draw_card",
+          "type":"effect"
+        }],
+      "inputs":[]
+    }
+  },
+  "attr":"ANI",
+  "cost":1,
+  "icon":"card-meditation",
+  "name":"Chained Energy",
+  "set":"sage"
+}

--- a/game/database/domains/card/concentration.json
+++ b/game/database/domains/card/concentration.json
@@ -3,19 +3,19 @@
   "cost":1,
   "desc":"",
   "icon":"card-focus-gem",
-  "name":"Focus Gem",
+  "name":"Concentration",
   "set":"sage",
   "type-description":"",
   "widget":{
-    "charges":1,
-    "equipment":false,
+    "charges":2,
     "operators":[{
         "attr":"ARC",
         "op":"+",
         "val":2
       }],
     "status-tags":[],
-    "trigger":"on_focus_end"
+    "trigger":"on_focus_end",
+    "equipment":false
   },
   "art":false,
   "one_time":false

--- a/game/database/domains/card/firebolt.json
+++ b/game/database/domains/card/firebolt.json
@@ -4,7 +4,7 @@
       "effects":[{
           "attr":"=arc",
           "base":0,
-          "mod":30,
+          "mod":50,
           "name":"damage_on_target",
           "sfx":"example",
           "target":"=body",

--- a/game/database/domains/card/firebolt.json
+++ b/game/database/domains/card/firebolt.json
@@ -9,10 +9,6 @@
           "sfx":"example",
           "target":"=body",
           "type":"effect"
-        },{
-          "amount":1,
-          "name":"gain_focus",
-          "type":"effect"
         }],
       "inputs":[{
           "body-only":[],

--- a/game/database/domains/card/firebolt.json
+++ b/game/database/domains/card/firebolt.json
@@ -3,15 +3,15 @@
     "art_ability":{
       "effects":[{
           "attr":"=arc",
-          "mod":100,
           "base":0,
+          "mod":30,
           "name":"damage_on_target",
           "sfx":"example",
           "target":"=body",
           "type":"effect"
         },{
           "amount":1,
-          "name":"draw_card",
+          "name":"gain_focus",
           "type":"effect"
         }],
       "inputs":[{
@@ -32,10 +32,10 @@
           "type":"operator",
           "which":"ARC"
         }]
-    },
+    }
   },
-  "cost":1,
   "attr":"ARC",
+  "cost":2,
   "desc":"'Ouch that hurts! - Imp with his face on fire.",
   "icon":"card-firebolt",
   "name":"Firebolt",

--- a/game/database/domains/card/laser-cut.json
+++ b/game/database/domains/card/laser-cut.json
@@ -3,9 +3,9 @@
     "art_ability":{
       "effects":[{
           "attr":"=cor",
-          "mod":150,
+          "mod":40,
           "name":"damage_on_target",
-          "base":0,
+          "base":8,
           "sfx":"attack-hit",
           "target":"=target_body",
           "type":"effect"

--- a/game/database/domains/card/strike.json
+++ b/game/database/domains/card/strike.json
@@ -3,9 +3,8 @@
     "art_ability":{
       "effects":[{
           "attr":"=cor",
-          "base":30,
-          "base":0,
-          "mod":40,
+          "base":2,
+          "mod":30,
           "name":"damage_on_target",
           "sfx":"attack-hit",
           "target":"=target_body",

--- a/game/domain/actor.lua
+++ b/game/domain/actor.lua
@@ -624,6 +624,10 @@ function Actor:spendFocus(n)
   self.focus = math.max(0, self.focus - n)
 end
 
+function Actor:gainFocus(n)
+  self.focus = math.min(self.focus + n, DEFS.ACTION.MAX_FOCUS)
+end
+
 function Actor:checkFocus()
   if self.focus == 0 then
     self:endFocus()

--- a/game/domain/definitions/attribute.lua
+++ b/game/domain/definitions/attribute.lua
@@ -11,7 +11,7 @@ ATTR.INFLUENCE = {
 }
 
 function ATTR.EFFECTIVE_POWER(base, attr, mod)
-  return math.floor(base + attr * mod / 100)
+  return math.max(1, math.floor(base + attr * mod / 100))
 end
 
 return ATTR

--- a/game/domain/effects/gain_focus.lua
+++ b/game/domain/effects/gain_focus.lua
@@ -1,0 +1,27 @@
+
+local FX = {}
+
+FX.schema = {
+  { id = 'amount', name = "Focus Amount", type = 'value',
+    match = 'integer', range = {1,3} },
+}
+
+function FX.preview(_, fieldvalues)
+  return ("Gain %s Focus"):format(fieldvalues['amount'])
+end
+
+function FX.process (actor, fieldvalues)
+  local amount = fieldvalues['amount']
+  actor:gainFocus(amount)
+
+  coroutine.yield('report', {
+    type = 'text_rise',
+    text_type = 'focus',
+    body = actor:getBody(),
+    amount = amount,
+  })
+  return amount
+end
+
+return FX
+

--- a/game/view/spritefx/text_rise.lua
+++ b/game/view/spritefx/text_rise.lua
@@ -15,6 +15,7 @@ local _NUMBER_COLOR = {
   damage = 'NOTIFICATION',
   heal = 'SUCCESS',
   food = 'PP',
+  focus = 'FOCUS',
   status = 'WARNING'
 }
 
@@ -22,6 +23,7 @@ local _SIGNALS = {
   ['blocked-damage'] = '↓-',
   damage = '-',
   heal = '+',
+  focus = '+',
   food = '+',
 }
 


### PR DESCRIPTION
Closes #1196, with a few changes. The new sage deck consists of:

+ 4x Firebolt (2 focus, causes low damage)
+ 1x Arcane Burst (3 focus, causes medium damage in area)
+ 4x Concentration (1 focus, +2 ARC til end of next focused turn)
+ 1x Chained Energy (1 focus, +2 focus and draw a card)