### PR TITLE
FoV performance improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .*
 !.git*
 /lua51*
+/profiling
 savedir
 /log*
 import

--- a/game/common/profiler.lua
+++ b/game/common/profiler.lua
@@ -1,0 +1,84 @@
+
+-- luacheck: globals love
+
+local SWITCHER    = require 'infra.switcher'
+local Class       = require 'steaming.extra_libs.hump.class'
+
+local Profiler = Class{}
+
+local SAMPLES = 10
+
+function Profiler:init()
+  self.profiling = {}
+  self.last_state = nil
+  self.output = io.open("profiling", "w")
+end
+
+function Profiler:update(dt)
+  local GS = require 'gamestates'
+  local state = self.last_state
+  self.last_state = SWITCHER.current()
+  if state then
+    local name = "???"
+    for k,v in pairs(GS) do
+      if v == state then
+        name = k
+        break
+      end
+    end
+    if dt > 0.2 then
+      local warning = ("%.2f lag on state %s at frame %d\n"):format(
+        dt, name, GS[name].frame or -1
+      )
+      self.output:write(warning)
+      print(warning)
+      for _, slice in ipairs(self.slices) do
+        self.output:write(("%16s: %.3f\n"):format(slice.name, 1000*slice.span))
+      end
+    end
+    local sample = self.profiling[name] or { times = {} , n = 1 }
+    sample.times[sample.n] = dt
+    sample.n = (sample.n % SAMPLES) + 1
+    self.profiling[name] = sample
+  end
+  self:start()
+end
+
+function Profiler:start()
+  self.started_at = love.timer.getTime()
+  self.slices = { n = 0 }
+end
+
+function Profiler:mark(name)
+  if not self.slices then return end
+  local n = self.slices.n + 1
+  local t = love.timer.getTime()
+  local dt = t - self.started_at
+  self.started_at = t
+  self.slices[n] = { span = dt, name = name }
+  self.slices.n = n
+end
+
+local function average(sample)
+  local sum = 0
+  for _,time in ipairs(sample.times) do
+    sum = sum + time
+  end
+  return sum / math.max(#sample.times, SAMPLES)
+end
+
+function Profiler:draw()
+  local g = love.graphics
+  g.push()
+  g.origin()
+  g.setColor(1,1,1)
+  local i = 0
+  for name,sample in pairs(self.profiling) do
+    g.print(("%s: %.2f"):format(name, 1 / average(sample)), 32, 32+i*32)
+    i = i + 1
+  end
+  g.pop()
+end
+
+return Profiler()
+

--- a/game/common/profiler.lua
+++ b/game/common/profiler.lua
@@ -32,8 +32,8 @@ function Profiler:update(dt)
       )
       self.output:write(warning)
       print(warning)
-      for _, slice in ipairs(self.slices) do
-        self.output:write(("%16s: %.3f\n"):format(slice.name, 1000*slice.span))
+      for mark, slice in pairs(self.slices) do
+        self.output:write(("%16s: %.3f\n"):format(mark, 1000*slice))
       end
     end
     local sample = self.profiling[name] or { times = {} , n = 1 }
@@ -46,17 +46,15 @@ end
 
 function Profiler:start()
   self.started_at = love.timer.getTime()
-  self.slices = { n = 0 }
+  self.slices = {}
 end
 
 function Profiler:mark(name)
   if not self.slices then return end
-  local n = self.slices.n + 1
   local t = love.timer.getTime()
   local dt = t - self.started_at
   self.started_at = t
-  self.slices[n] = { span = dt, name = name }
-  self.slices.n = n
+  self.slices[name] = (self.slices[name] or 0) + dt
 end
 
 local function average(sample)

--- a/game/domain/sector.lua
+++ b/game/domain/sector.lua
@@ -388,33 +388,24 @@ function Sector:spreadDrops(i, j, drops)
 end
 
 function _turnLoop(self)
-  local PF = require 'common.profiler'
   local actors_queue = self.actors_queue
   while true do
-
-    PF:mark("start turn loop")
 
     for body in pairs(self.bodies) do
       if type(body) == 'table' then
         body:tick()
       end
     end
-    PF:mark("body tick")
 
     --Initialize actor queue
     for _,actor in ipairs(self.actors) do
       actor:tick()
-      PF:mark("actor tick")
       actor:grabDrops(self:getTile(actor:getPos()))
-      PF:mark("actor grab drops")
       actor:updateFov(self)
-      PF:mark("actor update fov")
       table.insert(actors_queue, actor)
-      PF:mark("actor add to queue")
     end
 
     manageDeadBodiesAndUpdateActorsQueue(self, actors_queue)
-    PF:mark("queue update")
 
     while not Util.tableEmpty(actors_queue) do
       local actor = table.remove(actors_queue, 1)
@@ -431,7 +422,6 @@ function _turnLoop(self)
         break
       end
     end
-    PF:mark("actor actions")
 
   end
 end

--- a/game/domain/sector.lua
+++ b/game/domain/sector.lua
@@ -388,24 +388,33 @@ function Sector:spreadDrops(i, j, drops)
 end
 
 function _turnLoop(self)
+  local PF = require 'common.profiler'
   local actors_queue = self.actors_queue
   while true do
+
+    PF:mark("start turn loop")
 
     for body in pairs(self.bodies) do
       if type(body) == 'table' then
         body:tick()
       end
     end
+    PF:mark("body tick")
 
     --Initialize actor queue
     for _,actor in ipairs(self.actors) do
       actor:tick()
+      PF:mark("actor tick")
       actor:grabDrops(self:getTile(actor:getPos()))
+      PF:mark("actor grab drops")
       actor:updateFov(self)
-      table.insert(actors_queue,actor)
+      PF:mark("actor update fov")
+      table.insert(actors_queue, actor)
+      PF:mark("actor add to queue")
     end
 
     manageDeadBodiesAndUpdateActorsQueue(self, actors_queue)
+    PF:mark("queue update")
 
     while not Util.tableEmpty(actors_queue) do
       local actor = table.remove(actors_queue, 1)
@@ -422,6 +431,7 @@ function _turnLoop(self)
         break
       end
     end
+    PF:mark("actor actions")
 
   end
 end

--- a/game/main.lua
+++ b/game/main.lua
@@ -32,6 +32,7 @@ local PROFILE  = require 'infra.profile'
 local RUNFLAGS = require 'infra.runflags'
 local INPUT    = require 'input'
 local DB       = require 'database'
+local PROFILER = require 'common.profiler'
 
 local SOUNDTRACK
 
@@ -85,39 +86,8 @@ function love.load(arg)
   })
 end
 
---local SAMPLES = 10
---local profiling = {}
---local last_state
---
---function updateProfiling(dt)
---  local state = last_state
---  last_state = SWITCHER.current()
---  if not state then return end
---  local name = "???"
---  for k,v in pairs(GS) do
---    if v == state then
---      name = k
---      break
---    end
---  end
---  if dt > 0.2 then
---    print("lag on state", name)
---  end
---  local sample = profiling[name] or { times = {} , n = 1 }
---  sample.times[sample.n] = dt
---  sample.n = (sample.n % SAMPLES) + 1
---  profiling[name] = sample
---end
---
---function average(sample)
---  local sum = 0
---  for _,time in ipairs(sample.times) do
---    sum = sum + time
---  end
---  return sum / math.max(#sample.times, SAMPLES)
---end
-
 function love.update(dt)
+  PROFILER:update(dt)
   MAIN_TIMER:update(dt)
   if INPUT.wasActionReleased('QUIT') then
     love.event.quit()
@@ -129,7 +99,6 @@ function love.update(dt)
     SWITCHER.push(GS.DEVMODE)
   end
   SWITCHER.update(dt)
-  --updateProfiling(dt)
   INPUT.flush() -- must be called afterwards
   Util.updateSubtype(dt, 'task')
   Draw.update(dt)
@@ -139,16 +108,6 @@ end
 
 function love.draw()
   SWITCHER.draw()
-  --local g = love.graphics
-  --g.push()
-  --g.origin()
-  --g.setColor(1,1,1)
-  --local i = 0
-  --for name,sample in pairs(profiling) do
-  --  g.print(("%s: %.2f"):format(name, 1 / average(sample)), 32, 32+i*32)
-  --  i = i + 1
-  --end
-  --g.pop()
 end
 
 function love.quit()

--- a/game/view/sector/bodyview.lua
+++ b/game/view/sector/bodyview.lua
@@ -42,7 +42,7 @@ function BodyView:setPosition(i, j)
 end
 
 function BodyView:moveTo(i, j, t, curve)
-  curve = curve or 'out-cubic'
+  curve = curve or 'in-out-cubic'
   local deferred = Deferred:new{}
   local target = BodyView.tileToScreen(i, j)
   assert(not self:getTimer("move_to", MAIN_TIMER))


### PR DESCRIPTION
Close #1292

+ Use a cache to avoid recalculating FoV every tick
+ Stop scanning FoV after `actor:getFovRange()` rows
+ And some other lesser improvements

This PR includes an improved profiler too.