### PR TITLE
Static abilities

### DIFF
--- a/game/database/domains/card/arcane-burst.json
+++ b/game/database/domains/card/arcane-burst.json
@@ -2,7 +2,7 @@
   "art":{
     "art_ability":{
       "effects":[{
-          "amount":"=amount",
+          "value":"=amount",
           "center":"=self_pos",
           "ignore_owner":true,
           "name":"damage_on_area",

--- a/game/database/domains/card/auto-fire.json
+++ b/game/database/domains/card/auto-fire.json
@@ -9,7 +9,7 @@
     "auto_activation":{
       "ability":{
         "effects":[{
-            "amount":"=amount",
+            "value":"=amount",
             "name":"damage_on_target",
             "projectile":true,
             "sfx":"attack-hit",

--- a/game/database/domains/card/bloodthirst.json
+++ b/game/database/domains/card/bloodthirst.json
@@ -35,6 +35,44 @@
     },
     "charges":12,
     "operators":[],
+    "static":[{
+        "op":"damage_on_target",
+        "replacement-ability":{
+          "effects":[{
+              "attr":"=attr",
+              "base":"=base+2",
+              "mod":"=mod",
+              "name":"damage_on_target",
+              "sfx":"attack-hit",
+              "target":"=target",
+              "type":"effect"
+            }],
+          "inputs":[{
+              "name":"integer",
+              "output":"base",
+              "type":"input"
+            },{
+              "name":"integer",
+              "output":"mod",
+              "type":"input"
+            },{
+              "name":"integer",
+              "output":"attr",
+              "type":"input"
+            },{
+              "name":"body",
+              "output":"target",
+              "type":"input"
+            },{
+              "lhs":"=base",
+              "name":"integer_binop",
+              "op":"+",
+              "output":"base+2",
+              "rhs":2,
+              "type":"operator"
+            }]
+        }
+      }],
     "status-tags":[],
     "tactical-hint":"helpful",
     "trigger":"on_turn"

--- a/game/database/domains/card/bloodthirst.json
+++ b/game/database/domains/card/bloodthirst.json
@@ -36,12 +36,12 @@
     "charges":12,
     "operators":[],
     "static":[{
-        "descr":"Whenever you deal damage, you deal an\nadditional 2 damage.",
+        "descr":"Whenever you deal damage, you deal an\nadditional 1 damage for each other\ncreature within 3 tiles of you.",
         "op":"damage_on_target",
         "replacement-ability":{
           "effects":[{
               "attr":"=attr",
-              "base":"=base+2",
+              "base":"=base+x",
               "mod":"=mod",
               "name":"damage_on_target",
               "sfx":"attack-hit",
@@ -65,11 +65,33 @@
               "output":"target",
               "type":"input"
             },{
+              "name":"self",
+              "output":"self",
+              "type":"operator"
+            },{
+              "actor":"=self",
+              "name":"get_actor_body",
+              "output":"self_body",
+              "type":"operator"
+            },{
+              "body":"=self_body",
+              "name":"get_body_pos",
+              "output":"self_pos",
+              "type":"operator"
+            },{
+              "ignore-owner":true,
+              "name":"count_nearby_bodies",
+              "output":"count",
+              "pos":"=self_pos",
+              "range":3,
+              "type":"operator",
+              "body-type":false
+            },{
               "lhs":"=base",
               "name":"integer_binop",
               "op":"+",
-              "output":"base+2",
-              "rhs":2,
+              "output":"base+x",
+              "rhs":"=count",
               "type":"operator"
             }]
         }

--- a/game/database/domains/card/bloodthirst.json
+++ b/game/database/domains/card/bloodthirst.json
@@ -36,6 +36,7 @@
     "charges":12,
     "operators":[],
     "static":[{
+        "descr":"Whenever you deal damage, you deal an\nadditional 2 damage.",
         "op":"damage_on_target",
         "replacement-ability":{
           "effects":[{

--- a/game/database/domains/card/bloodthirst.json
+++ b/game/database/domains/card/bloodthirst.json
@@ -8,9 +8,7 @@
     "auto_activation":{
       "ability":{
         "effects":[{
-            "attr":"=ani",
-            "base":2,
-            "mod":50,
+            "value":"=amount",
             "name":"heal",
             "target":"=self-body",
             "type":"effect"
@@ -25,10 +23,12 @@
             "output":"self-body",
             "type":"operator"
           },{
-            "name":"get_attribute",
-            "output":"ani",
-            "type":"operator",
-            "which":"ANI"
+            "attr":"ANI",
+            "base":2,
+            "mod":50,
+            "name":"effective_power",
+            "output":"amount",
+            "type":"operator"
           }]
       },
       "trigger":"on_kill"
@@ -46,19 +46,12 @@
               "name":"damage_on_target",
               "sfx":"attack-hit",
               "target":"=target",
-              "type":"effect"
+              "type":"effect",
+              "value":"=base+x"
             }],
           "inputs":[{
               "name":"integer",
-              "output":"base",
-              "type":"input"
-            },{
-              "name":"integer",
-              "output":"mod",
-              "type":"input"
-            },{
-              "name":"integer",
-              "output":"attr",
+              "output":"value",
               "type":"input"
             },{
               "name":"body",
@@ -87,7 +80,7 @@
               "type":"operator",
               "body-type":false
             },{
-              "lhs":"=base",
+              "lhs":"=value",
               "name":"integer_binop",
               "op":"+",
               "output":"base+x",

--- a/game/database/domains/card/bone-club-crush.json
+++ b/game/database/domains/card/bone-club-crush.json
@@ -2,7 +2,7 @@
   "art":{
     "art_ability":{
       "effects":[{
-          "amount":"=amount",
+          "value":"=amount",
           "name":"damage_on_target",
           "sfx":"attack-hit",
           "target":"=target-body",

--- a/game/database/domains/card/chained-energy.json
+++ b/game/database/domains/card/chained-energy.json
@@ -10,7 +10,7 @@
     "auto_activation":{
       "ability":{
         "effects":[{
-            "amount":"=amount",
+            "value":"=amount",
             "name":"damage_on_target",
             "projectile":true,
             "sfx":"attack-hit",

--- a/game/database/domains/card/energy-beam.json
+++ b/game/database/domains/card/energy-beam.json
@@ -2,7 +2,7 @@
   "art":{
     "art_ability":{
       "effects":[{
-          "amount":"=amount",
+          "value":"=amount",
           "center":"=target_pos",
           "name":"damage_on_area",
           "sfx":"attack-hit",

--- a/game/database/domains/card/fireball.json
+++ b/game/database/domains/card/fireball.json
@@ -2,7 +2,7 @@
   "art":{
     "art_ability":{
       "effects":[{
-          "amount":"=amount",
+          "value":"=amount",
           "center":"=target",
           "name":"damage_on_area",
           "projectile":true,

--- a/game/database/domains/card/firebolt.json
+++ b/game/database/domains/card/firebolt.json
@@ -2,7 +2,7 @@
   "art":{
     "art_ability":{
       "effects":[{
-          "amount":"=amount",
+          "value":"=amount",
           "name":"damage_on_target",
           "projectile":true,
           "sfx":"attack-hit",

--- a/game/database/domains/card/flurry-of-blows.json
+++ b/game/database/domains/card/flurry-of-blows.json
@@ -2,19 +2,19 @@
   "art":{
     "art_ability":{
       "effects":[{
-          "amount":"=amount",
+          "value":"=amount",
           "name":"damage_on_target",
           "sfx":"attack-hit",
           "target":"=t1",
           "type":"effect"
         },{
-          "amount":"=amount",
+          "value":"=amount",
           "name":"damage_on_target",
           "sfx":"attack-hit",
           "target":"=t2",
           "type":"effect"
         },{
-          "amount":"=amount",
+          "value":"=amount",
           "name":"damage_on_target",
           "sfx":"attack-hit",
           "target":"=t3",

--- a/game/database/domains/card/greater-jump.json
+++ b/game/database/domains/card/greater-jump.json
@@ -10,7 +10,7 @@
           "vfx-spd":4,
           "sfx":false
         },{
-          "amount":"=amount",
+          "value":"=amount",
           "center":"=pos",
           "ignore_owner":true,
           "name":"damage_on_area",

--- a/game/database/domains/card/greater-rush.json
+++ b/game/database/domains/card/greater-rush.json
@@ -10,7 +10,7 @@
           "vfx-spd":1,
           "sfx":false
         },{
-          "amount":"=amount",
+          "value":"=amount",
           "center":"=damage_pos",
           "name":"damage_on_area",
           "sfx":"attack-hit",

--- a/game/database/domains/card/heal.json
+++ b/game/database/domains/card/heal.json
@@ -2,7 +2,7 @@
   "art":{
     "art_ability":{
       "effects":[{
-          "amount":"=amount",
+          "value":"=amount",
           "name":"heal",
           "target":"=self",
           "type":"effect"

--- a/game/database/domains/card/hook-n-uppercut.json
+++ b/game/database/domains/card/hook-n-uppercut.json
@@ -2,7 +2,7 @@
   "art":{
     "art_ability":{
       "effects":[{
-          "amount":"=amount",
+          "value":"=amount",
           "name":"damage_on_target",
           "sfx":"attack-hit",
           "target":"=target-body",

--- a/game/database/domains/card/jump.json
+++ b/game/database/domains/card/jump.json
@@ -10,7 +10,7 @@
           "vfx-spd":4,
           "sfx":false
         },{
-          "amount":"=amount",
+          "value":"=amount",
           "center":"=target_pos",
           "ignore_owner":true,
           "name":"damage_on_area",

--- a/game/database/domains/card/lead-pipe-strike.json
+++ b/game/database/domains/card/lead-pipe-strike.json
@@ -2,7 +2,7 @@
   "art":{
     "art_ability":{
       "effects":[{
-          "amount":"=amount",
+          "value":"=amount",
           "name":"damage_on_target",
           "sfx":"attack-hit",
           "target":"=body",

--- a/game/database/domains/card/old-laddle-strike.json
+++ b/game/database/domains/card/old-laddle-strike.json
@@ -2,7 +2,7 @@
   "art":{
     "art_ability":{
       "effects":[{
-          "amount":"=amount",
+          "value":"=amount",
           "name":"damage_on_target",
           "sfx":"attack-hit",
           "target":"=target_body",

--- a/game/database/domains/card/proximity-detector.json
+++ b/game/database/domains/card/proximity-detector.json
@@ -13,7 +13,7 @@
             "target":"=body_self",
             "type":"effect"
           },{
-            "amount":"=amount",
+            "value":"=amount",
             "center":"=pos",
             "name":"damage_on_area",
             "sfx":"attack-hit",

--- a/game/database/domains/card/reckless-smash.json
+++ b/game/database/domains/card/reckless-smash.json
@@ -2,7 +2,7 @@
   "art":{
     "art_ability":{
       "effects":[{
-          "amount":"=amount",
+          "value":"=amount",
           "name":"damage_on_target",
           "sfx":"attack-hit",
           "target":"=target",

--- a/game/database/domains/card/roundhouse-kick.json
+++ b/game/database/domains/card/roundhouse-kick.json
@@ -2,7 +2,7 @@
   "art":{
     "art_ability":{
       "effects":[{
-          "amount":"=amount",
+          "value":"=amount",
           "center":"=self-pos",
           "ignore_owner":true,
           "name":"damage_on_area",

--- a/game/database/domains/card/rush.json
+++ b/game/database/domains/card/rush.json
@@ -10,7 +10,7 @@
           "vfx-spd":1,
           "sfx":false
         },{
-          "amount":"=amount",
+          "value":"=amount",
           "center":"=damage_pos",
           "name":"damage_on_area",
           "sfx":"attack-hit",

--- a/game/database/domains/card/rusty-blaster-shot.json
+++ b/game/database/domains/card/rusty-blaster-shot.json
@@ -2,7 +2,7 @@
   "art":{
     "art_ability":{
       "effects":[{
-          "amount":"=amount",
+          "value":"=amount",
           "name":"damage_on_target",
           "projectile":true,
           "sfx":"attack-hit",

--- a/game/database/domains/card/self-destruct.json
+++ b/game/database/domains/card/self-destruct.json
@@ -9,7 +9,7 @@
     "auto_activation":{
       "ability":{
         "effects":[{
-            "amount":"=amount",
+            "value":"=amount",
             "center":"=pos",
             "name":"damage_on_area",
             "sfx":"attack-hit",

--- a/game/database/domains/card/sonic-boom.json
+++ b/game/database/domains/card/sonic-boom.json
@@ -2,7 +2,7 @@
   "art":{
     "art_ability":{
       "effects":[{
-          "amount":"=amount",
+          "value":"=amount",
           "center":"=damage_pos",
           "name":"damage_on_area",
           "sfx":"attack-hit",

--- a/game/database/domains/card/spark-rod-aoe.json
+++ b/game/database/domains/card/spark-rod-aoe.json
@@ -2,7 +2,7 @@
   "art":{
     "art_ability":{
       "effects":[{
-          "amount":"=amount",
+          "value":"=amount",
           "center":"=target-pos",
           "ignore_owner":true,
           "name":"damage_on_area",

--- a/game/database/domains/card/spark-rod-target.json
+++ b/game/database/domains/card/spark-rod-target.json
@@ -2,7 +2,7 @@
   "art":{
     "art_ability":{
       "effects":[{
-          "amount":"=amount",
+          "value":"=amount",
           "name":"damage_on_target",
           "sfx":"attack-hit",
           "target":"=target-body",

--- a/game/database/domains/card/sticky_flame.json
+++ b/game/database/domains/card/sticky_flame.json
@@ -9,7 +9,7 @@
     "auto_activation":{
       "ability":{
         "effects":[{
-            "amount":"=amount",
+            "value":"=amount",
             "name":"damage_on_target",
             "sfx":"attack-hit",
             "target":"=body_self",

--- a/game/database/domains/card/stomp.json
+++ b/game/database/domains/card/stomp.json
@@ -9,7 +9,7 @@
           "size":3,
           "type":"effect"
         },{
-          "amount":"=amount",
+          "value":"=amount",
           "center":"=pos",
           "ignore_owner":true,
           "name":"damage_on_area",

--- a/game/database/domains/card/strike.json
+++ b/game/database/domains/card/strike.json
@@ -2,7 +2,7 @@
   "art":{
     "art_ability":{
       "effects":[{
-          "amount":"=amount",
+          "value":"=amount",
           "name":"damage_on_target",
           "sfx":"attack-hit",
           "target":"=target_body",

--- a/game/database/domains/card/trained-strike.json
+++ b/game/database/domains/card/trained-strike.json
@@ -2,7 +2,7 @@
   "art":{
     "art_ability":{
       "effects":[{
-          "amount":"=amount",
+          "value":"=amount",
           "name":"damage_on_target",
           "sfx":"attack-hit",
           "target":"=target_body",

--- a/game/database/schema/card.lua
+++ b/game/database/schema/card.lua
@@ -1,4 +1,5 @@
 
+local ABILITY = require 'domain.ability'
 local DEFS = require 'domain.definitions'
 
 local _CARDS = 'domains.card'
@@ -38,6 +39,17 @@ return {
         options = DEFS.TRIGGERS },
       { id = 'trigger-condition', name = "Spend Trigger Condition",
         type = 'ability', optional = true },
+      {
+        id = 'static', name = "Static Abilities",
+        type = 'array', schema = {
+          { id = 'op', name = "Operation or Effect", type = 'enum',
+            options = ABILITY.allOperationsAndEffects() },
+          { id = 'replacement-ability', name = "Condition and Replacement",
+            type = 'ability',
+            hint = "When the inputs are met, the operation\n" ..
+                   "or effect are replaced by the effects here" },
+        }
+      },
       {
         id = 'operators', name = "Static Attribute Operator",
         type = 'array', schema = {

--- a/game/database/schema/card.lua
+++ b/game/database/schema/card.lua
@@ -48,6 +48,7 @@ return {
             type = 'ability',
             hint = "When the inputs are met, the operation\n" ..
                    "or effect are replaced by the effects here" },
+          { id = 'descr', name = "Rules Text", type = 'text' },
         }
       },
       {

--- a/game/devmode/view/input/ability.lua
+++ b/game/devmode/view/input/ability.lua
@@ -1,4 +1,6 @@
 
+-- luacheck: no self
+
 local ABILITY     = require 'domain.ability'
 local IMGUI       = require 'imgui'
 local DB          = require 'database'
@@ -9,6 +11,7 @@ local table = table
 local ipairs = ipairs
 local require = require
 local setfenv = setfenv
+local pcall = pcall
 
 local _CMDTYPES = {
   'inputs', 'effects',
@@ -152,12 +155,15 @@ function AbilityEditor:instance(obj, _elementspec, _fieldschema)
       IMGUI.Text("Preview")
       IMGUI.Indent(20)
       IMGUI.PushItemWidth(360)
-      local descr = ABILITY.preview(_ability, {}, {})
+      local ok, descr = pcall(ABILITY.preview,_ability, {}, {})
+      if not ok then
+        descr = "Could not preview ability"
+      end
       local text = ""
       for _, line in ipairs(_split(descr, 40)) do
         text = text .. line .. "\n"
       end
-      IMGUI.InputTextMultiline("", text, 1024, 0, 0, { "ReadOnly" })
+      IMGUI.InputTextMultiline("", text, 1024, 0, 40, { "ReadOnly" })
       IMGUI.PopItemWidth()
       IMGUI.Unindent(40)
     end

--- a/game/devmode/view/input/reference.lua
+++ b/game/devmode/view/input/reference.lua
@@ -1,6 +1,5 @@
 
 local IMGUI = require 'imgui'
-local DB = require 'database'
 local class = require 'lux.class'
 
 local setfenv = setfenv
@@ -9,14 +8,16 @@ local ipairs = ipairs
 local pairs = pairs
 local require = require
 local type = type
+local tostring = tostring
 
 local OutputEditor = class:new()
 
+-- luacheck: no self
 function OutputEditor:instance(obj, _elementspec, _fieldschema)
 
   setfenv(1, obj)
 
-  function input(gui)
+  function input(_) -- luacheck: no global
     IMGUI.PushID(_fieldschema.id)
     IMGUI.Text(_fieldschema.name)
     local value, changed = IMGUI.InputText("", _elementspec[_fieldschema.id]
@@ -27,7 +28,7 @@ function OutputEditor:instance(obj, _elementspec, _fieldschema)
     IMGUI.PopID()
   end
 
-  function __operator:call(gui)
+  function __operator:call(gui) -- luacheck: no global
     return obj.input(gui)
   end
 end
@@ -42,11 +43,11 @@ function ValueEditor:instance(obj, _elementspec, _fieldschema, _parent)
   local inputStr = require 'devmode.view.helpers.string'
 
   local function _appendRefs(from, to, match)
-    for k,item in pairs(from) do
+    for _,item in pairs(from) do
       if item == _elementspec then return false end
       local t = require(('domain.%ss.%s'):format(item.type, item.name)).type
       if not t or t == match then
-        table.insert(to, "=" .. item.output)
+        table.insert(to, "=" .. tostring(item.output))
       end
     end
     return true
@@ -55,6 +56,7 @@ function ValueEditor:instance(obj, _elementspec, _fieldschema, _parent)
   local function _getRefs()
     local refs = {}
     _appendRefs(_parent.inputs, refs, _fieldschema.match)
+    _appendRefs(_parent.effects, refs, _fieldschema.match)
     local idx = 0
     for i,ref in ipairs(refs) do
       if ref == _elementspec[_fieldschema.id] then
@@ -80,7 +82,7 @@ function ValueEditor:instance(obj, _elementspec, _fieldschema, _parent)
     _use_ref = false
   end
 
-  function input(gui)
+  function input(_) -- luacheck: no global
     IMGUI.PushID(_fieldschema.id)
     IMGUI.Text(_fieldschema.name)
     local changed
@@ -102,12 +104,12 @@ function ValueEditor:instance(obj, _elementspec, _fieldschema, _parent)
 
     if _fieldschema.match == 'integer' or _fieldschema.match == 'string' then
       IMGUI.SameLine()
-      _use_ref, changed = IMGUI.Checkbox("Ref##".._fieldschema.id, _use_ref)
+      _use_ref, _ = IMGUI.Checkbox("Ref##".._fieldschema.id, _use_ref)
     end
     IMGUI.PopID()
   end
 
-  function __operator:call(gui)
+  function __operator:call(gui) -- luacheck: no global
     return obj.input(gui)
   end
 end

--- a/game/domain/ability.lua
+++ b/game/domain/ability.lua
@@ -97,9 +97,24 @@ local function _getMatchedAbilities(actor, name, field_values, applied)
   end
 end
 
+local function _joinAppliedAbilities(current_ability, previous_abilities)
+  local apply = {}
+  apply[current_ability] = true
+  for k, v in pairs(previous_abilities or {}) do
+    apply[k] = v
+  end
+  return apply
+end
+
 local _CMDLISTS = { 'inputs', 'effects' }
 local _CMDMAP = { operator = OP, effect = FX }
 
+-- TODO:
+--  + Multiple instances of an ability apply at most once
+--  + Expanded ability can only import integer and string values from matching
+--    command
+--  + Do something about ability previews
+--  + Implement queries?
 function ABILITY.execute(ability, actor, inputvalues)
   -- Register map of values computed by inputs, operators, and effects
   local values = {}
@@ -147,14 +162,8 @@ function ABILITY.execute(ability, actor, inputvalues)
             -- Insert in the front side of the deque
             table.insert(deque, i, expanded_cmd)
             -- Mark as applied to avoid endless recursion
-            local apply = {}
-            apply[expanded_ability] = true
-            if applied_abilities then
-              for k, v in pairs(applied_abilities) do
-                apply[k] = v
-              end
-            end
-            applied[expanded_cmd] = apply
+            applied[expanded_cmd] = _joinAppliedAbilities(expanded_ability,
+                                                          applied_abilities)
             redirect[expanded_cmd] = cmd['output']
           end
         -- If the command is not expanded, process it normally.

--- a/game/domain/ability.lua
+++ b/game/domain/ability.lua
@@ -16,6 +16,20 @@ end
 
 local ABILITY = {}
 
+function ABILITY.allOperationsAndEffects()
+  local t = {}
+  local n = 1
+  for _,option in DB.subschemaTypes('operators') do
+    t[n] = option
+    n = n + 1
+  end
+  for _,option in DB.subschemaTypes('effects') do
+    t[n] = option
+    n = n + 1
+  end
+  return t
+end
+
 function ABILITY.inputsOf(ability)
   return ipairs(ability.inputs)
 end

--- a/game/domain/ability.lua
+++ b/game/domain/ability.lua
@@ -78,12 +78,6 @@ end
 local _CMDLISTS = { 'inputs', 'effects' }
 local _CMDMAP = { operator = OP, effect = FX }
 
--- TODO:
---  + Expanded ability can only import integer and string registers from matching
---    command
---  + Static abilities do not work on input checks or previews
---  + Implement queries?
-
 -- Every helper function used here is either const or mutates only the values
 -- it returns.
 local _hashAbility, _matches, _matchAbilities, _copySourceAbilities,

--- a/game/domain/card.lua
+++ b/game/domain/card.lua
@@ -117,6 +117,10 @@ function Card:getWidgetTriggerCondition()
   return self:getSpec('widget')['trigger-condition']
 end
 
+function Card:getStaticAbilities()
+  return ipairs(self:getSpec('widget')['static'] or {})
+end
+
 function Card:getStaticOperators()
   return ipairs(self:getSpec('widget')['operators'] or {})
 end

--- a/game/domain/card.lua
+++ b/game/domain/card.lua
@@ -218,8 +218,8 @@ function Card:getEffect()
     effect = effect .. "Single-Use "
   end
   if self:isArt() then
-    effect = effect .. ("Art (%d focus)\n\n"):format(self:getCost())
-                    .. ABILITY.preview(self:getArtAbility(), self:getOwner(),
+    effect = effect .. "Art\n\n"
+    effect = effect .. ABILITY.preview(self:getArtAbility(), self:getOwner(),
                                        inputs, true)
   elseif self:isWidget() then
     local place = self:getWidgetPlacement() if place then
@@ -227,22 +227,33 @@ function Card:getEffect()
     else
       effect = effect .. "Condition"
     end
-    effect = effect .. (" (%d focus"):format(self:getCost())
     local charges = self:getWidgetCharges() if charges > 0 then
       local trigger = self:getWidgetTrigger()
-      effect = effect .. (", %d charges%s"):format(
+      effect = effect .. (" (%d charges%s)"):format(
         charges,
         trigger and "/" .. trigger or ""
       )
     end
-    effect = effect .. ")"
-    local ops, n = {}, 0
-    for _,op in self:getStaticOperators() do
-      n = n + 1
-      ops[n] = ("%s %s%d"):format(op.attr, op.op, op.val)
+    do -- static abilities
+      local abs, n = {}, 0
+      for _,ab in self:getStaticAbilities() do
+        n = n + 1
+        abs[n] = ab.descr ~= "" and ab.descr
+                                 or "Missing static ability description."
+      end
+      if n > 0 then
+        effect = effect .. "\n\n" .. table.concat(abs, "\n\n")
+      end
     end
-    if n > 0 then
-      effect = effect .. "\n\n" .. table.concat(ops, ", ") .. "."
+    do -- static operators
+      local ops, n = {}, 0
+      for _,op in self:getStaticOperators() do
+        n = n + 1
+        ops[n] = ("%s %s%d"):format(op.attr, op.op, op.val)
+      end
+      if n > 0 then
+        effect = effect .. "\n\n" .. table.concat(ops, ", ") .. "."
+      end
     end
     local auto = self:getWidgetTriggeredAbility() if auto then
       local ability, trigger = auto.ability, TRIGGERS.WORDING[auto.trigger]

--- a/game/domain/card.lua
+++ b/game/domain/card.lua
@@ -249,7 +249,7 @@ function Card:getEffect()
       local ops, n = {}, 0
       for _,op in self:getStaticOperators() do
         n = n + 1
-        ops[n] = ("%s %s%d"):format(op.attr, op.op, op.val)
+        ops[n] = ("You get %s %s%d"):format(op.attr, op.op, op.val)
       end
       if n > 0 then
         effect = effect .. "\n\n" .. table.concat(ops, ", ") .. "."

--- a/game/domain/effects/damage_on_area.lua
+++ b/game/domain/effects/damage_on_area.lua
@@ -6,7 +6,7 @@ FX.schema = {
   { id = 'center', name = "Target position", type = 'value', match = 'pos' },
   { id = 'size', name = "Area Size", type = 'value', match = 'integer',
     range = {1} },
-  { id = 'amount', name = "Amount", type = 'value', match = 'integer',
+  { id = 'value', name = "value", type = 'value', match = 'integer',
     range = {0,100} },
   { id = 'ignore_owner', name = "Ignore Owner", type = 'boolean'},
   { id = 'projectile', name = "Is projectile?", type = 'boolean' },
@@ -16,14 +16,14 @@ FX.schema = {
 }
 
 function FX.preview (_, fieldvalues)
-  local amount = fieldvalues['amount']
+  local value = fieldvalues['value']
   local size = fieldvalues['size'] - 1
   local center = fieldvalues['center']
   if size > 0 then
     return ("deal %s damage on a %s-radius area around %s")
-           :format(amount, size, center)
+           :format(value, size, center)
   else
-    return ("deal %s damage at %s"):format(amount, center)
+    return ("deal %s damage at %s"):format(value, center)
   end
 end
 
@@ -32,7 +32,7 @@ function FX.process (actor, fieldvalues)
   local ci, cj  = unpack(fieldvalues['center'])
   local size    = fieldvalues['size']
   local ignore_owner = fieldvalues['ignore_owner']
-  local amount = fieldvalues['amount']
+  local value = fieldvalues['value']
   if fieldvalues['projectile'] then
     coroutine.yield('report', {
       type = 'projectile',
@@ -45,7 +45,7 @@ function FX.process (actor, fieldvalues)
       local body = sector:getBodyAt(i, j) if body then
         if (not ignore_owner or body ~= actor:getBody()) and
             TILE.dist(i,j,ci,cj) <= size - 1 then
-          local result = body:takeDamageFrom(amount, actor)
+          local result = body:takeDamageFrom(value, actor)
           coroutine.yield('report', {
             type = 'take_damage',
             source = actor,

--- a/game/domain/effects/damage_on_target.lua
+++ b/game/domain/effects/damage_on_target.lua
@@ -3,7 +3,7 @@ local FX = {}
 
 FX.schema = {
   { id = 'target', name = "Target", type = 'value', match = 'body' },
-  { id = 'amount', name = "Amount", type = 'value', match = 'integer',
+  { id = 'value', name = "value", type = 'value', match = 'integer',
     range = {0,100} },
   { id = 'projectile', name = "Is projectile?", type = 'boolean' },
   { id = 'sfx', name = "SFX", type = 'enum',
@@ -13,15 +13,15 @@ FX.schema = {
 }
 
 function FX.preview (_, fieldvalues)
-  local amount = fieldvalues['amount']
+  local value = fieldvalues['value']
   local target = fieldvalues['target']
-  return ("deal %s damage to %s"):format(amount, target)
+  return ("deal %s damage to %s"):format(value, target)
 end
 
 function FX.process (actor, fieldvalues)
-  local amount = fieldvalues['amount']
+  local value = fieldvalues['value']
   local target = fieldvalues['target']
-  local result = target:takeDamageFrom(amount, actor)
+  local result = target:takeDamageFrom(value, actor)
 
   if fieldvalues['projectile'] then
     coroutine.yield('report', {

--- a/game/domain/effects/damage_on_target.lua
+++ b/game/domain/effects/damage_on_target.lua
@@ -9,6 +9,7 @@ FX.schema = {
   { id = 'sfx', name = "SFX", type = 'enum',
     options = 'resources.sfx',
     optional = true },
+  { id = 'output', name = "Label", type = 'output' }
 }
 
 function FX.preview (_, fieldvalues)

--- a/game/domain/effects/heal.lua
+++ b/game/domain/effects/heal.lua
@@ -3,23 +3,23 @@ local FX = {}
 
 FX.schema = {
   { id = 'target', name = "Target", type = 'value', match = 'body' },
-  { id = 'amount', name = "Amount", type = 'value', match = 'integer',
+  { id = 'value', name = "value", type = 'value', match = 'integer',
     range = {0,100} }
 }
 
 function FX.preview(_, fieldvalues)
   return ("heal %s hit points to %s")
-         :format(fieldvalues['amount'], fieldvalues['target'])
+         :format(fieldvalues['value'], fieldvalues['target'])
 end
 
 function FX.process(_, fieldvalues)
   local target = fieldvalues['target']
-  local amount = fieldvalues['amount']
-  local effective_amount = target:heal(amount)
+  local value = fieldvalues['value']
+  local effective_value = target:heal(value)
   coroutine.yield('report', {
     type = 'heal',
     body = target,
-    amount = effective_amount,
+    amount = effective_value,
   })
 end
 

--- a/game/domain/inputs/enum.lua
+++ b/game/domain/inputs/enum.lua
@@ -1,0 +1,15 @@
+
+local INPUT = {}
+
+INPUT.schema = {
+  { id = 'output', name = "Label", type = 'output' }
+}
+
+INPUT.type = 'enum'
+
+function INPUT.isValid(_, _, _)
+  return true
+end
+
+return INPUT
+

--- a/game/domain/inputs/integer.lua
+++ b/game/domain/inputs/integer.lua
@@ -1,0 +1,15 @@
+
+local INPUT = {}
+
+INPUT.schema = {
+  { id = 'output', name = "Label", type = 'output' }
+}
+
+INPUT.type = 'integer'
+
+function INPUT.isValid(_, _, _)
+  return true
+end
+
+return INPUT
+

--- a/game/domain/inputs/is_same_enum.lua
+++ b/game/domain/inputs/is_same_enum.lua
@@ -1,0 +1,17 @@
+
+local INPUT = {}
+
+INPUT.schema = {
+  { id = 'lhs', name = "Left value", type = 'value', match = 'enum' },
+  { id = 'rhs', name = "Right value", type = 'string' },
+  { id = 'output', name = "Label", type = 'output' },
+}
+
+INPUT.type = 'boolean'
+
+function INPUT.isValid(_, fieldvalues, _)
+  return fieldvalues['lhs'] == fieldvalues['rhs']
+end
+
+return INPUT
+

--- a/game/domain/inputs/is_same_integer.lua
+++ b/game/domain/inputs/is_same_integer.lua
@@ -1,0 +1,17 @@
+
+local INPUT = {}
+
+INPUT.schema = {
+  { id = 'lhs', name = "Left value", type = 'value', match = 'integer' },
+  { id = 'rhs', name = "Right value", type = 'value', match = 'integer' },
+  { id = 'output', name = "Label", type = 'output' },
+}
+
+INPUT.type = 'boolean'
+
+function INPUT.isValid(_, fieldvalues, _)
+  return fieldvalues['lhs'] == fieldvalues['rhs']
+end
+
+return INPUT
+


### PR DESCRIPTION
Static abilities are abilities that widget cards can have. They change how the effects created by their owner work using the ability system itself. I changed the *Bloodthirst* card to show what these mechanics are capable of: it now increases damage you cause by 1 for every nearby creature. It does not trigger an additional damage — it *replaces* the damage you would deal by the orignal + the number of nearby creatures.

Static abilities have 3 fields:

#### Operation of Effect
The name of the command the static ability replaces (as the name suggests, only works on operators and effects, not inputs).

#### Condition and Replacement
This field is an ability like an Art's main ability or a Widget's triggered ability. However, it is used very differently. Whenever the static ability's owner makes an effect or operator whose name matches the one in the static ability, its input commands run using the original command's parameters as inputs. If no input command fails, the static ability is a **match**. It then proceeds to replace the matched command by its sequence of effect commands, which may, in turn, match more static abilities.

#### Rules Text
Since static abilities are very specific, I chose to provide this field so we can manually write the rules the players will see.

## Notes

I recommend reading the documentation for `ABILITY.execute` for the details. Note that static abilities may expand "recursively", but this PR guarantees that the same ability is not expanded more than once in the same "branch" of expanded commands AND that different ability instances do match in the same "branch". That is, it hopefully does what you expect when you have 2 or more *Bloodthirst* conditions.

Aside from that, this PR has the following limitations:

+ When carrying the matched command's field values as inputs for the static ability, the code currently knows only how to use integers and strings. We need more input commands for other types.
+ The previous issue is further aggravated by the fact that reference fields in commands can only use constant values if they are integers or strings.
+ Static abilities do not work on input checks or previews.
+ Reading the state of a game element now may no longer tell its "effective" state. Maybe we could use the ability system to allow querying the "effective" values of attributes, etc.
