### PR TITLE
Use tree editor for ability commands.

### DIFF
--- a/game/devmode/view/input/ability.lua
+++ b/game/devmode/view/input/ability.lua
@@ -20,6 +20,8 @@ local _idgen = IDGenerator()
 
 local AbilityEditor = class:new()
 
+-- luacheck: no self
+
 local function _split(str, max_line_length)
    local lines = {}
    local line
@@ -43,12 +45,35 @@ function AbilityEditor:instance(obj, _elementspec, _fieldschema)
 
   local _ability = _elementspec[_fieldschema.id] or
                    { inputs = {}, effects = {} }
-  local _selected = nil
   local _active = not (not _elementspec[_fieldschema.id] and
                            _fieldschema.optional)
 
-  local function _delete()
-    table.remove(_ability[_selected.cmdtype], _selected.idx)
+  local _cmd_editors = {}
+  local SPEC_EDITOR = require 'devmode.view.specification_editor'
+  for _,cmdtype in ipairs(_CMDTYPES) do
+    _cmd_editors[cmdtype] = {}
+  end
+
+  local function _bind_delete(cmdtype, i)
+    return function ()
+      table.remove(_ability[cmdtype], i)
+      for _, editor in ipairs(_cmd_editors[cmdtype]) do
+        editor.dirty = true
+      end
+    end
+  end
+
+  local function _editor_for(cmdtype, i)
+    local cmd = _ability[cmdtype][i]
+    local editor_list = _cmd_editors[cmdtype]
+    if not editor_list[i] or editor_list[i].dirty then
+      local _, _, renderer = SPEC_EDITOR(cmd, cmd.type .. 's/' .. cmd.name,
+                                         _CMDTYPES[cmdtype],
+                                         _bind_delete(cmdtype, i), nil,
+                                         _ability)
+      editor_list[i] = { render = renderer, dirty = false }
+    end
+    return editor_list[i]
   end
 
   local function _commandList(gui, cmdtype)
@@ -79,15 +104,9 @@ function AbilityEditor:instance(obj, _elementspec, _fieldschema)
         view = ("%2d: %s"):format(i, command.name)
       end
       IMGUI.PushID(("%s/%s:%d"):format(_ability, cmdtype, i))
-      if IMGUI.Selectable(view,
-                          _selected and _selected.cmdtype == cmdtype
-                                    and _selected.idx == i) then
-        _selected = _selected or {}
-        _selected.cmdtype = cmdtype
-        _selected.idx = i
-        gui:push('specification_editor', command,
-                 command.type .. 's/' .. command.name, _CMDTYPES[cmdtype],
-                 _delete, nil, _ability)
+      if IMGUI.TreeNode(view) then
+        _editor_for(cmdtype, i).render(gui)
+        IMGUI.TreePop()
       end
       IMGUI.PopID()
     end
@@ -113,7 +132,7 @@ function AbilityEditor:instance(obj, _elementspec, _fieldschema)
     IMGUI.Unindent(20)
   end
 
-  function input(gui)
+  function input(gui) -- luacheck: no global
     if _fieldschema.optional then
       IMGUI.PushID(_fieldschema.id .. ".check")
       _active = IMGUI.Checkbox("", _active)
@@ -144,7 +163,7 @@ function AbilityEditor:instance(obj, _elementspec, _fieldschema)
     end
   end
 
-  function __operator:call(gui)
+  function __operator:call(gui) -- luacheck: no global
     return obj.input(gui)
   end
 

--- a/game/devmode/view/input/ability.lua
+++ b/game/devmode/view/input/ability.lua
@@ -104,7 +104,7 @@ function AbilityEditor:instance(obj, _elementspec, _fieldschema)
         view = ("%2d: %s"):format(i, command.name)
       end
       IMGUI.PushID(("%s/%s:%d"):format(_ability, cmdtype, i))
-      if IMGUI.TreeNode(view) then
+      if IMGUI.TreeNodeEx(view, { "Framed" }) then
         _editor_for(cmdtype, i).render(gui)
         IMGUI.TreePop()
       end

--- a/game/devmode/view/specification_editor.lua
+++ b/game/devmode/view/specification_editor.lua
@@ -12,22 +12,30 @@ return function(elementspec, group_name, title, delete, rename, parent)
     table.insert(inputs, INPUT(elementspec, fieldschema, parent))
   end
 
-  return title .. " Editor", 2, function(gui)
-
-    -- meta actions
-    local spec_meta = getmetatable(elementspec)
-    if spec_meta and spec_meta.is_leaf and IMGUI.Button("Save##1") then
-      DB.save(elementspec)
+  local function _meta_buttons(gui, spec_meta)
+    if spec_meta and spec_meta.is_leaf then
+      if IMGUI.Button("Save##1") then
+        DB.save(elementspec)
+      end
+      IMGUI.SameLine()
     end
-    IMGUI.SameLine()
-    if rename and IMGUI.Button("Rename##1") then
-      gui:push('name_input', title, rename)
+    if rename then
+      if IMGUI.Button("Rename##1") then
+        gui:push('name_input', title, rename)
+      end
+      IMGUI.SameLine()
     end
-    IMGUI.SameLine()
     if IMGUI.Button("Delete##1") then
       delete()
       return true
     end
+  end
+
+  return title .. " Editor", 2, function(gui)
+
+    -- meta actions
+    local spec_meta = getmetatable(elementspec)
+    if _meta_buttons(gui, spec_meta) then return true end
     IMGUI.Spacing()
     IMGUI.Separator()
     IMGUI.Spacing()
@@ -55,18 +63,7 @@ return function(elementspec, group_name, title, delete, rename, parent)
     IMGUI.Spacing()
     IMGUI.Separator()
     IMGUI.Spacing()
-    if spec_meta and spec_meta.is_leaf and IMGUI.Button("Save##2") then
-      DB.save(elementspec)
-    end
-    IMGUI.SameLine()
-    if rename and IMGUI.Button("Rename##2") then
-      gui:push('name_input', title, rename)
-    end
-    IMGUI.SameLine()
-    if IMGUI.Button("Delete##2") then
-      delete()
-      return true
-    end
+    if _meta_buttons(gui, spec_meta) then return true end
   end
 
 end


### PR DESCRIPTION
Partially attends #828.

With this PR, editing abilities in cards should be a smoother experience since you can see and change multiple commands at the same time.