### PR TITLE
Allow the game to start outside the player's turn

### DIFF
--- a/game/gamestates/play.lua
+++ b/game/gamestates/play.lua
@@ -175,8 +175,9 @@ end
 
 function state:update(_)
   --FIXME:this doesn't need to happen every update (I think)
-  if _route.getControlledActor() or _player then
-    _view.sector:updateFov(_route.getControlledActor() or _player)
+  _player = _player or _route.getControlledActor() or _route.getPlayerActor()
+  if _player then
+    _view.sector:updateFov(_player)
   else
     return error("missing player")
   end
@@ -184,7 +185,7 @@ function state:update(_)
   if _next_action then
     _playTurns(unpack(_next_action))
   end
-  _view.sector:lookAt(_route.getControlledActor() or _player)
+  _view.sector:lookAt(_player)
 end
 
 function state:resume(from, args)

--- a/game/view/gameplay/actionhud/buffer.lua
+++ b/game/view/gameplay/actionhud/buffer.lua
@@ -124,7 +124,7 @@ function BufferView:getTopCardPosition(index_offset)
 end
 
 function BufferView:update(dt)
-  local actor = self.route.getControlledActor()
+  local actor = self.route.getPlayerActor()
   if self.side == 'front' then
     self.button:setCost(actor:getBody():getConsumption())
     self.button:update(dt)

--- a/game/view/gameplay/actionhud/focusbar.lua
+++ b/game/view/gameplay/actionhud/focusbar.lua
@@ -1,5 +1,5 @@
 
--- luacheck: SWITCHER GS globals love
+-- luacheck: globals love SWITCHER GS MAIN_TIMER
 
 local FONT        = require 'view.helpers.font'
 local COLORS      = require 'domain.definitions.colors'
@@ -93,8 +93,7 @@ function FocusBar:update(dt)
     self.explosions[i]:update(dt)
   end
 
-  local _OFF_SPD = 2.5
-  self.actor = self.route.getControlledActor()
+  self.actor = self.route.getPlayerActor()
 
   --update fade-in
   local maxfocus = ACTIONDEFS.MAX_FOCUS

--- a/game/view/sector.lua
+++ b/game/view/sector.lua
@@ -347,7 +347,7 @@ function SectorView:draw()
         if body then
           table.insert(draw_bodies, body)
           table.insert(all_bodies, body)
-          local player = self.route.getControlledActor():getBody()
+          local player = self.route.getPlayerActor():getBody()
           local player_i, player_j = player:getPos()
           local body_i, body_j = body:getPos()
           if body:getDialogue() then


### PR DESCRIPTION
Otherwise it crashes when you load a save written at a bad time.