### PR TITLE
Use more direct computation for monsters' upgrades

### DIFF
--- a/game/database/domains/body/npc-welcome.json
+++ b/game/database/domains/body/npc-welcome.json
@@ -19,7 +19,7 @@
         "droptype":"pack"
       }]
   },
-  "extends":"corgi",
+  "extends":"npc-base",
   "faction":"allied",
   "name":"Welcomer"
 }

--- a/game/database/domains/sector/sector01.json
+++ b/game/database/domains/sector/sector01.json
@@ -30,14 +30,13 @@
   "encounters":{
     "max":16,
     "min":12,
+    "upgrade_power":70,
     "recipes":[{
         "actorspec":"dumb-slime",
-        "bodyspec":"slime",
-        "upgrade_power":100
+        "bodyspec":"slime"
       },{
         "actorspec":"dumb-stove",
-        "bodyspec":"stove",
-        "upgrade_power":120
+        "bodyspec":"stove"
       }]
   },
   "exits":{

--- a/game/database/domains/sector/sector02.json
+++ b/game/database/domains/sector/sector02.json
@@ -30,14 +30,13 @@
   "encounters":{
     "max":10,
     "min":5,
+    "upgrade_power":300,
     "recipes":[{
         "actorspec":"grinful-imp",
-        "bodyspec":"imp",
-        "upgrade_power":120
+        "bodyspec":"imp"
       },{
         "actorspec":"dumb-stove",
-        "bodyspec":"stove",
-        "upgrade_power":130
+        "bodyspec":"stove"
       }]
   },
   "exits":{

--- a/game/database/domains/sector/sector03.json
+++ b/game/database/domains/sector/sector03.json
@@ -26,14 +26,13 @@
   "encounters":{
     "max":12,
     "min":6,
+    "upgrade_power":500,
     "recipes":[{
         "actorspec":"fiendish-eye",
-        "bodyspec":"eye",
-        "upgrade_power":150
+        "bodyspec":"eye"
       },{
-        "actorspec":"dumb-slime",
-        "bodyspec":"slime",
-        "upgrade_power":240
+        "actorspec":"grinful-imp",
+        "bodyspec":"imp"
       }]
   },
   "exits":{

--- a/game/database/domains/sector/sector_final.json
+++ b/game/database/domains/sector/sector_final.json
@@ -33,10 +33,10 @@
   "encounters":{
     "max":14,
     "min":6,
+    "upgrade_power":800,
     "recipes":[{
         "actorspec":"newbieslayer",
-        "bodyspec":"rewasvat",
-        "upgrade_power":300
+        "bodyspec":"rewasvat"
       }]
   },
   "exits":{

--- a/game/domain/builders/sector.lua
+++ b/game/domain/builders/sector.lua
@@ -62,9 +62,6 @@ function _placeBodiesAndActors(idgenerator, state, encounters)
   state.bodies = {}
   state.actors = {}
 
-  local zone_spec = DB.loadSpec('zone', state.zone)
-  local difficulty_multiplier = 1 + zone_spec['difficulty']
-
   for _,encounter in ipairs(encounters) do
     local actor_specname, body_specname = unpack(encounter.creature)
     local i, j = unpack(encounter.pos)
@@ -79,23 +76,8 @@ function _placeBodiesAndActors(idgenerator, state, encounters)
 
       local upgradexp = encounter.upgrade_power
       if upgradexp then
-        upgradexp = math.floor(upgradexp * difficulty_multiplier)
-        -- allocating exp
-        if upgradexp > 0 then
-          local total = 0
-          local aptitudes = {}
-          local actor_spec = DB.loadSpec('actor', actor_specname)
-          for _,attr in ipairs(DEFS.PRIMARY_ATTRIBUTES) do
-            aptitudes[attr] = actor_spec[attr:lower()] + 3 -- min of 1
-            total = total + aptitudes[attr]
-          end
-          local unit = upgradexp / total
-          for attr,priority in pairs(aptitudes) do
-            local award = math.floor(unit * priority)
-            if DEFS.PRIMARY_ATTRIBUTES[attr] then
-              actor_state.upgrades[attr] = DEFS.ATTR.INITIAL_UPGRADE + award
-            end
-          end
+        for _,attr in ipairs(DEFS.PRIMARY_ATTRIBUTES) do
+          actor_state.upgrades[attr] = DEFS.ATTR.INITIAL_UPGRADE + upgradexp
         end
       end
     end

--- a/game/domain/transformers/encounters.lua
+++ b/game/domain/transformers/encounters.lua
@@ -9,14 +9,14 @@ transformer.schema = {
     range = {1} },
   { id = 'max', name = "Maximum number of encounters", type = 'integer',
     range = {1} },
+  { id = 'upgrade_power', name = "Upgrade Power", type = 'integer',
+    range = {10,1000} },
   { id = 'recipes', name = "Encounter recipe", type = 'array',
     schema = {
       { id = 'actorspec', name = "Actor Specification", type = 'enum',
         options = 'domains.actor' },
       { id = 'bodyspec', name = "Body Specification", type = 'enum',
         options = 'domains.body' },
-      { id = 'upgrade_power', name = "Upgrade Power", type = 'integer',
-        range = {10,1000} },
     } }
 }
 
@@ -34,8 +34,8 @@ function transformer.process(sectorinfo, params)
   for _=1,total do
     local encounter = {}
     local recipe = recipes[RANDOM.generate(1,#recipes)]
-    local upgrade_power = math.floor(0.8 + 0.4*RANDOM.generate()
-                                     * recipe.upgrade_power)
+    local upgrade_power = math.floor((0.9 + 0.2 * RANDOM.generate())
+                                     * params.upgrade_power)
     encounter.upgrade_power = upgrade_power
     encounter.creature = { recipe.actorspec, recipe.bodyspec }
     local minj, maxj, mini, maxi = grid.getRange()


### PR DESCRIPTION
What you type into the sector specs will be added to all the monsters'
attributes equally, but with a 10% variation.

Close #1433