### PR TITLE
Preview static abilities in other abilities

### DIFF
--- a/game/common/formula.lua
+++ b/game/common/formula.lua
@@ -1,0 +1,33 @@
+
+local Class = require "steaming.extra_libs.hump.class"
+
+local Formula = Class{}
+
+function Formula:init(value, base_text, bonus)
+  self.value = value
+  self.base_text = base_text
+  self.bonus = bonus or 0
+end
+
+function Formula:__add(rhs)
+  return Formula(self.value, self.base_text, self.bonus + rhs)
+end
+
+function Formula:__sub(rhs)
+  return Formula(self.value, self.base_text, self.bonus - rhs)
+end
+
+function Formula:__tostring()
+  local bonus = ""
+  if self.bonus ~= 0 then
+    bonus = (" + %d"):format(self.bonus)
+  end
+  local amount = ""
+  if self.value then
+    amount = ("%d "):format(self.value + self.bonus)
+  end
+  return ("%s(%s%s)"):format(amount, self.base_text, bonus)
+end
+
+return Formula
+

--- a/game/database/domains/card/bloodthirst.json
+++ b/game/database/domains/card/bloodthirst.json
@@ -1,18 +1,18 @@
 {
   "attr":"ANI",
-  "level":4,
   "cost":3,
   "icon":"card-bloodthirst",
+  "level":4,
   "name":"Bloodthirst",
   "set":"support_common",
   "widget":{
     "auto_activation":{
       "ability":{
         "effects":[{
-            "value":"=amount",
             "name":"heal",
             "target":"=self-body",
-            "type":"effect"
+            "type":"effect",
+            "value":"=amount"
           }],
         "inputs":[{
             "name":"self",
@@ -37,26 +37,20 @@
     "charges":12,
     "operators":[],
     "static":[{
-        "descr":"Whenever you deal damage, you deal an\nadditional 1 damage for each other\ncreature within 3 tiles of you.",
+        "descr":"Whenever you deal targeted damage,\nyou deal +1 damage for each other\ncreature within 3 tiles of you.",
         "op":"damage_on_target",
         "replacement-ability":{
           "effects":[{
-              "attr":"=attr",
-              "base":"=base+x",
-              "mod":"=mod",
-              "name":"damage_on_target",
-              "sfx":"attack-hit",
-              "target":"=target",
-              "type":"effect",
-              "value":"=base+x"
+              "lhs":"=value",
+              "name":"integer_binop",
+              "op":"+",
+              "output":"value",
+              "rhs":"=count",
+              "type":"operator"
             }],
           "inputs":[{
               "name":"integer",
               "output":"value",
-              "type":"input"
-            },{
-              "name":"body",
-              "output":"target",
               "type":"input"
             },{
               "name":"self",
@@ -80,13 +74,6 @@
               "range":3,
               "type":"operator",
               "body-type":false
-            },{
-              "lhs":"=value",
-              "name":"integer_binop",
-              "op":"+",
-              "output":"base+x",
-              "rhs":"=count",
-              "type":"operator"
             }]
         }
       }],

--- a/game/database/schema/card.lua
+++ b/game/database/schema/card.lua
@@ -47,7 +47,7 @@ return {
           { id = 'op', name = "Operation or Effect", type = 'enum',
             options = ABILITY.allOperationsAndEffects() },
           { id = 'replacement-ability', name = "Condition and Replacement",
-            type = 'ability',
+            type = 'ability', disable_effects = true,
             hint = "When the inputs are met, the operation\n" ..
                    "or effect are replaced by the effects here" },
           { id = 'descr', name = "Rules Text", type = 'text' },

--- a/game/devmode/view/input/ability.lua
+++ b/game/devmode/view/input/ability.lua
@@ -88,9 +88,11 @@ function AbilityEditor:instance(obj, _elementspec, _fieldschema)
     local list = _ability[cmdtype] or {}
     _ability[cmdtype] = list
 
-    for _,option in DB.subschemaTypes(cmdtype) do
-      table.insert(cmdoptions, option)
-      table.insert(cmdtypes, cmdtype:sub(1,-2))
+    if cmdtype ~= 'effects' or not _fieldschema.disable_effects then
+      for _,option in DB.subschemaTypes(cmdtype) do
+        table.insert(cmdoptions, option)
+        table.insert(cmdtypes, cmdtype:sub(1,-2))
+      end
     end
 
     for _,option in DB.subschemaTypes('operators') do

--- a/game/domain/inputs/register.lua
+++ b/game/domain/inputs/register.lua
@@ -1,0 +1,13 @@
+
+local INPUT = {}
+
+INPUT.schema = {
+  { id = 'output', name = "Label", type = 'output' }
+}
+
+function INPUT.isValid(_, _, _)
+  return true
+end
+
+return INPUT
+

--- a/game/domain/operators/effective_power.lua
+++ b/game/domain/operators/effective_power.lua
@@ -4,6 +4,7 @@
 
 local DEFS = require 'domain.definitions'
 local ATTR = require 'domain.definitions.attribute'
+local Formula = require 'common.formula'
 
 local OP = {}
 
@@ -26,11 +27,11 @@ end
 
 function OP.preview(actor, fieldvalues)
   local base, attr, mod = fieldvalues.base, fieldvalues.attr, fieldvalues.mod
-  local amount = ""
+  local amount
   if actor.id then -- is it a valid actor?
-    amount = ("%d "):format(OP.process(actor, fieldvalues))
+    amount = OP.process(actor, fieldvalues)
   end
-  return ("%s(%d + %2d%% %s)"):format(amount, base, mod, attr)
+  return Formula(amount, ("%d + %2d%% %s"):format(base, mod, attr))
 end
 
 return OP


### PR DESCRIPTION
Also change how static abilities work. Instead of expanding matched
commands, they now preprocess the parameters of matched commands. In the
case of Bloodthirst, for instance, it adds 1 to the "value" parameter of
damage_on_target commands.

This simplification is what enables the more detailed preview of effects
in other cards, so a Strike card now properly indicates it is receiving
a +1 damage.