### PR TITLE
Balance Bloodthirst considering props

### DIFF
--- a/game/database/domains/card/bloodthirst.json
+++ b/game/database/domains/card/bloodthirst.json
@@ -9,12 +9,6 @@
     "auto_activation":{
       "ability":{
         "effects":[{
-            "name":"heal",
-            "target":"=self-body",
-            "type":"effect",
-            "value":"=amount"
-          }],
-        "inputs":[{
             "name":"self",
             "output":"self",
             "type":"operator"
@@ -30,6 +24,21 @@
             "name":"effective_power",
             "output":"amount",
             "type":"operator"
+          },{
+            "name":"heal",
+            "target":"=self-body",
+            "type":"effect",
+            "value":"=amount"
+          }],
+        "inputs":[{
+            "name":"body",
+            "output":"killed_body",
+            "type":"input"
+          },{
+            "body":"=killed_body",
+            "faction":"aggressive",
+            "name":"is_in_faction",
+            "type":"input"
           }]
       },
       "trigger":"on_kill"
@@ -37,7 +46,7 @@
     "charges":12,
     "operators":[],
     "static":[{
-        "descr":"Whenever you deal targeted damage,\nyou deal +1 damage for each other\ncreature within 3 tiles of you.",
+        "descr":"Whenever you deal targeted damage,\nyou deal +1 damage for each other\nhostile creature within 3 tiles\nof you.",
         "op":"damage_on_target",
         "replacement-ability":{
           "effects":[{
@@ -67,6 +76,7 @@
               "output":"self_pos",
               "type":"operator"
             },{
+              "faction":"aggressive",
               "ignore-owner":true,
               "name":"count_nearby_bodies",
               "output":"count",

--- a/game/domain/inputs/is_in_faction.lua
+++ b/game/domain/inputs/is_in_faction.lua
@@ -1,0 +1,19 @@
+
+local INPUT = {}
+
+INPUT.schema = {
+  { id = 'body', name = "Body", type = 'value', match = 'body' },
+  { id = 'faction', name = "Body Faction", type = 'enum',
+    options = 'domains.faction' },
+}
+
+INPUT.type = 'boolean'
+
+function INPUT.isValid(_, fieldvalues, _)
+  local body = fieldvalues['body']
+  local faction = fieldvalues['faction']
+  return body:getFaction() == faction
+end
+
+return INPUT
+

--- a/game/domain/operators/count_nearby_bodies.lua
+++ b/game/domain/operators/count_nearby_bodies.lua
@@ -7,6 +7,8 @@ OP.schema = {
     range = {0} },
   { id = 'body-type', name = "Body Type", type = 'enum',
     options = 'domains.body' },
+  { id = 'faction', name = "Body Faction", type = 'enum',
+    options = 'domains.faction' },
   { id = 'ignore-owner', name = "Ignore Owner", type = 'boolean' },
   { id = 'output', name = "Label", type = 'output' }
 }
@@ -23,12 +25,14 @@ function OP.process(actor, fieldvalues)
   local range = fieldvalues['range']
   local specname = fieldvalues['body-type']
   local notowner = fieldvalues['ignore-owner']
+  local faction = fieldvalues['faction']
   local count = 0
   for di=i-range,i+range do
     for dj=j-range,j+range do
       if di ~= i or dj ~= j then
         local body = sector:getBodyAt(di, dj)
         if body and body:isSpec(specname)
+                and (faction and body:getFaction() == faction)
                 and _checkOwner(actor, body, notowner) then
           count = count + 1
         end

--- a/game/domain/sector.lua
+++ b/game/domain/sector.lua
@@ -256,7 +256,8 @@ function Sector:removeDeadBodies()
         local killer_id = body:getKiller()
         local killer = Util.findId(killer_id)
         if killer then
-          killer:getBody():triggerWidgets(TRIGGERS.ON_KILL)
+          local inputs = { killed_body = body }
+          killer:getBody():triggerWidgets(TRIGGERS.ON_KILL, inputs)
         end
         -- Generate drops
         local drops_table = {}


### PR DESCRIPTION
Make it so Bloodthirst only counts hostile bodies and only heals after
killing hostile bodies as well.