### PR TITLE
Update FoV only when strictly necessary

### DIFF
--- a/game/domain/actor.lua
+++ b/game/domain/actor.lua
@@ -606,6 +606,7 @@ end
 --[[ Turn methods ]]--
 
 function Actor:grabDrops(tile)
+  if not tile then return end
   local drops = tile.drops
   local inputvalues = {}
   local n = #drops
@@ -686,6 +687,7 @@ function Actor:endTurn()
 end
 
 function Actor:makeAction()
+  self:updateFov(self:getBody():getSector())
   local success = false
   repeat
     local action_slot, params
@@ -698,7 +700,6 @@ function Actor:makeAction()
       success = ACTION.execute(action_slot, self, params)
     end
   until success
-  self:updateFov(self:getBody():getSector())
   return true
 end
 

--- a/game/domain/sector.lua
+++ b/game/domain/sector.lua
@@ -305,7 +305,10 @@ function Sector:removeActor(removed_actor)
 end
 
 function Sector:getBodyPos(body)
-  return unpack(self.bodies[body])
+  local pos = self.bodies[body]
+  if pos then
+    return unpack(pos)
+  end
 end
 
 function Sector:iterateActors()
@@ -408,10 +411,11 @@ function _turnLoop(self)
 
     --Initialize actor queue
     for _,actor in ipairs(self.actors) do
-      actor:tick()
-      actor:grabDrops(self:getTile(actor:getPos()))
-      actor:updateFov(self)
-      table.insert(actors_queue, actor)
+      if actor:getPos() then
+        actor:tick()
+        actor:grabDrops(self:getTile(actor:getPos()))
+        table.insert(actors_queue, actor)
+      end
     end
 
     manageDeadBodiesAndUpdateActorsQueue(self, actors_queue)
@@ -513,6 +517,7 @@ function Sector:playTurns(...)
   if not ok then
     return error(debug.traceback(self.turnLoop, err))
   else
+    self.route.getPlayerActor():updateFov(self)
     return unpack(result, 2)
   end
 end


### PR DESCRIPTION
That is, whenever it's the corresponding actor's turn OR whenever
execution flow goes back to the player, in which case we update the
player actor's FoV.