### PR TITLE
Persist a route at a configurable frequency

### DIFF
--- a/game/database/settings/user-preferences.json
+++ b/game/database/settings/user-preferences.json
@@ -8,5 +8,10 @@
     "default": 100,
     "range": [0, 100],
     "step": 10
+  },
+  "autosave-frequency": {
+    "default": 100,
+    "range": [0, 100],
+    "step": 5
   }
 }

--- a/game/gamestates/play.lua
+++ b/game/gamestates/play.lua
@@ -34,12 +34,18 @@ local _updateSoundtrack
 --LOCAL FUNCTION--
 
 local function _saveRoute()
+  PROFILE.saveRoute(_route.saveState())
+end
+
+local function _persistRoute()
   if PROFILE.getTutorial("finished_tutorial") then
-    PROFILE.saveRoute(_route.saveState())
+    _saveRoute()
+    PROFILE.persistRoute()
   end
 end
 
 local function _playTurns(...)
+
   local request, extra = _route.playTurns(...)
 
   _updateSoundtrack()
@@ -92,7 +98,7 @@ end
 
 function _activity:saveAndQuit()
   local fade_view = FadeView(FadeView.STATE_UNFADED)
-  _saveRoute()
+  _persistRoute()
   fade_view:register("GUI")
   fade_view:fadeOutAndThen(self.resume)
   self.wait()
@@ -162,7 +168,7 @@ end
 
 function state:leave()
 
-  _saveRoute()
+  _persistRoute()
   _route.destroyAll()
   _view:destroy()
   if RUNFLAGS.DEVELOPMENT then

--- a/game/gamestates/settings.lua
+++ b/game/gamestates/settings.lua
@@ -1,8 +1,11 @@
 
+-- luacheck: no self
+
 local DB           = require 'database'
 local INPUT        = require 'input'
 local DIRECTIONALS = require 'infra.dir'
 local PROFILE      = require 'infra.profile'
+local SWITCHER     = require 'infra.switcher'
 local PLAYSFX      = require 'helpers.playsfx'
 local SettingsView = require 'view.settings'
 local Draw         = require "draw"
@@ -45,19 +48,19 @@ function state:init()
   _selection = 1
 end
 
-function state:enter(from)
+function state:enter(_)
   _selection = 1
   _original = {}
   for _,field in ipairs(_fields) do
     _original[field] = PROFILE.getPreference(field) or _schema[field].default
     PROFILE.setPreference(field, _original[field])
   end
-  _changes = setmetatable({}, { __index = original })
+  _changes = setmetatable({}, { __index = _original })
   _view = SettingsView(_fields)
   _view:register("GUI")
 end
 
-function state:update(dt)
+function state:update(_)
   if INPUT.wasActionPressed("CONFIRM") then
     PLAYSFX('ok-menu')
     _save = true

--- a/game/infra/profile.lua
+++ b/game/infra/profile.lua
@@ -32,6 +32,14 @@ local _confirm
 local _compress
 local _last_route_state
 
+PROFILE.PREFERENCE = {
+  AUTOSAVE = 'autosave-frequency',
+  BGM_VOLUME = 'bgm-volume',
+  SFX_VOLUME = 'sfx-volume'
+}
+
+PROFILE.MAX_AUTOSAVE = 100
+
 local function _decompress(str) --> str
   if not _compress then return str end
   return assert(ZIP.decompress(str, "lz4"))
@@ -138,6 +146,7 @@ function PROFILE.saveRoute(route_data)
 end
 
 function PROFILE.persistRoute()
+  if not _last_route_state then return end
   -- add save to profile list
   _metadata.save_list[_last_route_state.id] = {
     player_name = _last_route_state.player_name,

--- a/game/infra/profile.lua
+++ b/game/infra/profile.lua
@@ -1,4 +1,6 @@
 
+-- luacheck: globals love VERSION
+
 local JSON         = require 'dkjson'
 local INPUT        = require 'input'
 
@@ -28,6 +30,7 @@ local _savethread
 local _channel
 local _confirm
 local _compress
+local _last_route_state
 
 local function _decompress(str) --> str
   if not _compress then return str end
@@ -131,15 +134,19 @@ function PROFILE.loadRoute(route_id)
 end
 
 function PROFILE.saveRoute(route_data)
+  _last_route_state = route_data
+end
+
+function PROFILE.persistRoute()
   -- add save to profile list
-  _metadata.save_list[route_data.id] = {
-    player_name = route_data.player_name,
-    player_dead = route_data.player_dead,
-    player_won  = route_data.player_won,
+  _metadata.save_list[_last_route_state.id] = {
+    player_name = _last_route_state.player_name,
+    player_dead = _last_route_state.player_dead,
+    player_won  = _last_route_state.player_won,
   }
   _channel:push({
-    filepath = SAVEDIR .. route_data.id,
-    data = route_data,
+    filepath = SAVEDIR .. _last_route_state.id,
+    data = _last_route_state,
     compress = _compress,
   })
   return _saveProfile()
@@ -170,7 +177,7 @@ function PROFILE.setPreference(field, value)
   _metadata.preferences[field] = value
 end
 
-function PROFILE.getTutorial(field, value)
+function PROFILE.getTutorial(field)
   local value = _metadata.tutorial[field]
   if not value then
     value = DB.loadSetting("tutorial")[field]

--- a/game/main.lua
+++ b/game/main.lua
@@ -90,6 +90,7 @@ function love.update(dt)
   PROFILER:update(dt)
   MAIN_TIMER:update(dt)
   if INPUT.wasActionReleased('QUIT') then
+    PROFILE.persistRoute()
     love.event.quit()
   elseif INPUT.wasActionPressed('DEVMODE') and not DEBUG
                                            and RUNFLAGS.DEVELOPMENT then


### PR DESCRIPTION
You can now set a frequency of 0% to 100%, where 100% means persisting every turn and 0% means persisting never. The game will *always* autosave upon a graceful exit though, but the route is no longer saved when the game crashes. In that case, it restores to the last turn-based autosave (or the last time you closed the game normally, if frequency is zero).